### PR TITLE
refactor(account): introduce AccountInterface protocol

### DIFF
--- a/budget_forecaster/account/__init__.py
+++ b/budget_forecaster/account/__init__.py
@@ -1,0 +1,13 @@
+"""Account module exports."""
+from budget_forecaster.account.account import Account, AccountParameters
+from budget_forecaster.account.account_interface import AccountInterface
+from budget_forecaster.account.aggregated_account import AggregatedAccount
+from budget_forecaster.account.persistent_account import PersistentAccount
+
+__all__ = [
+    "Account",
+    "AccountInterface",
+    "AccountParameters",
+    "AggregatedAccount",
+    "PersistentAccount",
+]

--- a/budget_forecaster/account/account_interface.py
+++ b/budget_forecaster/account/account_interface.py
@@ -1,0 +1,32 @@
+"""Module defining the AccountInterface protocol."""
+# pylint: disable=unnecessary-ellipsis
+from typing import Protocol
+
+from budget_forecaster.account.account import Account, AccountParameters
+from budget_forecaster.operation_range.historic_operation import HistoricOperation
+
+
+class AccountInterface(Protocol):
+    """Common interface for account managers."""
+
+    @property
+    def account(self) -> Account:
+        """Return the aggregated account."""
+        ...
+
+    @property
+    def accounts(self) -> tuple[Account, ...]:
+        """Return the individual accounts."""
+        ...
+
+    def upsert_account(self, account: AccountParameters) -> None:
+        """Add or update an account."""
+        ...
+
+    def replace_account(self, new_account: Account) -> None:
+        """Replace an existing account."""
+        ...
+
+    def replace_operation(self, new_operation: HistoricOperation) -> None:
+        """Replace an existing operation."""
+        ...

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -116,7 +116,7 @@ def load_persistent_account(
     persistent_account = PersistentAccount(database_path=config.database_path)
     try:
         persistent_account.load()
-        account = persistent_account.aggregated_account.account
+        account = persistent_account.account
         print("Loaded account:")
         print("Name:", account.name)
         print("Balance:", account.balance)
@@ -129,7 +129,7 @@ def load_persistent_account(
             f"Creating account {config.account.name} with currency {config.account.currency}"
         )
         # Save the account
-        persistent_account.aggregated_account.upsert_account(
+        persistent_account.upsert_account(
             AccountParameters(
                 name=config.account.name,
                 balance=0.0,
@@ -149,11 +149,11 @@ def handle_load_command(
     operation_factory: HistoricOperationFactory,
 ) -> None:
     """Handle the load command."""
-    persistent_account.aggregated_account.upsert_account(
+    persistent_account.upsert_account(
         load_bank_export(bank_export_path, operation_factory)
     )
     persistent_account.save()
-    account = persistent_account.aggregated_account.account
+    account = persistent_account.account
     print("New account state:")
     print("Name:", account.name)
     print("Balance:", account.balance)
@@ -223,14 +223,14 @@ def handle_categorize_command(
             print(f"No operation found with ID {operation_id}")
             sys.exit(1)
         new_operation = categorize_operation(operation)
-        persistent_account.aggregated_account.replace_operation(new_operation)
+        persistent_account.replace_operation(new_operation)
         persistent_account.save()
         sys.exit(0)
 
     for operation in sorted(account.operations, key=lambda op: op.date, reverse=True):
         if operation.category == Category.OTHER:
             new_operation = categorize_operation(operation)
-            persistent_account.aggregated_account.replace_operation(new_operation)
+            persistent_account.replace_operation(new_operation)
             persistent_account.save()
     sys.exit(0)
 
@@ -281,7 +281,7 @@ def handle_load_inbox_command(
     for export_item in export_items:
         try:
             print(f"Loading {export_item.name}...")
-            persistent_account.aggregated_account.upsert_account(
+            persistent_account.upsert_account(
                 load_bank_export(export_item, operation_factory)
             )
             persistent_account.save()
@@ -294,7 +294,7 @@ def handle_load_inbox_command(
         except (ValueError, OSError, KeyError) as e:
             print(f"  Error: {e}")
 
-    account = persistent_account.aggregated_account.account
+    account = persistent_account.account
     print()
     print(f"Imported {loaded_count} export(s)")
     print("Account state:")
@@ -319,7 +319,7 @@ def main() -> None:
     config.parse(Path(args.config))
 
     persistent_account = load_persistent_account(config)
-    account = persistent_account.aggregated_account.account
+    account = persistent_account.account
 
     # Create an operation factory
     operation_factory = HistoricOperationFactory(

--- a/tests/test_persistent_account.py
+++ b/tests/test_persistent_account.py
@@ -231,28 +231,24 @@ class TestPersistentAccount:  # pylint: disable=protected-access
         persistent2 = PersistentAccount(temp_db_path)
         persistent2.load()
 
-        assert persistent2.aggregated_account.account.name == "Mes comptes"
-        assert len(persistent2.aggregated_account.accounts) == 1
-        assert persistent2.aggregated_account.accounts[0].name == "Compte courant"
-        assert len(persistent2.aggregated_account.accounts[0].operations) == 3
+        assert persistent2.account.name == "Mes comptes"
+        assert len(persistent2.accounts) == 1
+        assert persistent2.accounts[0].name == "Compte courant"
+        assert len(persistent2.accounts[0].operations) == 3
 
         persistent2.close()
 
-    def test_aggregated_account_raises_when_not_loaded(
-        self, temp_db_path: Path
-    ) -> None:
-        """Test that accessing aggregated_account raises when not loaded."""
+    def test_account_raises_when_not_loaded(self, temp_db_path: Path) -> None:
+        """Test that accessing account raises when not loaded."""
         persistent = PersistentAccount(temp_db_path)
 
         with pytest.raises(FileNotFoundError):
-            _ = persistent.aggregated_account
+            _ = persistent.account
 
         persistent.close()
 
-    def test_upsert_account_via_aggregated(
-        self, temp_db_path: Path, sample_account: Account
-    ) -> None:
-        """Test upserting account through aggregated account interface."""
+    def test_upsert_account(self, temp_db_path: Path, sample_account: Account) -> None:
+        """Test upserting account through the interface."""
         persistent = PersistentAccount(temp_db_path)
         persistent._repository.initialize()
         persistent._aggregated_account = AggregatedAccount(
@@ -275,7 +271,7 @@ class TestPersistentAccount:  # pylint: disable=protected-access
             balance_date=datetime(2024, 2, 1),
             operations=(new_operation,),
         )
-        persistent.aggregated_account.upsert_account(new_account_params)
+        persistent.upsert_account(new_account_params)
         persistent.save()
         persistent.close()
 
@@ -283,7 +279,7 @@ class TestPersistentAccount:  # pylint: disable=protected-access
         persistent2 = PersistentAccount(temp_db_path)
         persistent2.load()
 
-        account = persistent2.aggregated_account.accounts[0]
+        account = persistent2.accounts[0]
         assert len(account.operations) == 4
 
         persistent2.close()


### PR DESCRIPTION
## Summary

- Create `AccountInterface` Protocol as a common interface for account managers
- Add delegate methods to `PersistentAccount` (account, accounts, upsert_account, replace_account, replace_operation)
- Remove public `aggregated_account` property from `PersistentAccount`
- Simplify API usage throughout `main.py`

## Before/After

```python
# Before
account = persistent_account.aggregated_account.account
persistent_account.aggregated_account.upsert_account(params)

# After
account = persistent_account.account
persistent_account.upsert_account(params)
```

## Test plan

- [x] All 149 tests pass
- [x] mypy: no issues
- [x] pylint: 10.00/10

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)