### PR TITLE
chore: add Claude Code guidelines and permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,6 @@
       "Bash(gh api *)",
       "Bash(pre-commit*)"
     ],
-    "deny": []
+    "deny": ["Bash(git add -A*)", "Bash(git add .*)"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ python -m budget_forecaster.main -c config.yaml categorize
 When addressing PR review comments:
 
 - **Always reply inline** to each comment using
-  `gh api repos/.../pulls/{pr}/comments/{id}/replies -X POST -f body="..."`
+  `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -X POST -f body="..."`
 - **Never post global comments** summarizing changes - each comment deserves its own
   inline response
 - Reference commit hashes and issue numbers in replies (e.g., "✅ Fixed in commit
@@ -117,7 +117,8 @@ All issues must be created in **English** with the following structure:
 ### Example
 
 ```bash
-gh issue create --title "feat: add multi-currency support" --body "## Context
+# Create issue and capture its number
+ISSUE_NUM=$(gh issue create --title "feat: add multi-currency support" --body "## Context
 Currently all amounts are hardcoded in EUR.
 
 ## Proposed solution
@@ -132,6 +133,7 @@ Currently all amounts are hardcoded in EUR.
 
 ## Related issues
 - Related to #36 (import filtering)
-"
-gh issue edit {id} --add-label "enhancement" --add-label "P2-medium"
+" | grep -oE '[0-9]+$')
+
+gh issue edit $ISSUE_NUM --add-label "enhancement" --add-label "P2-medium"
 ```


### PR DESCRIPTION
## Summary
- Add PR review workflow guidelines (always reply inline to comments)
- Add GitHub issue creation standards (English, labels, design proposal, links)
- Add missing git permissions (push, fetch, rebase, rm)

## Changes
- `.claude/settings.json`: Added git push/fetch/rebase/rm permissions
- `CLAUDE.md`: Added sections for PR review workflow and issue creation guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)