### PR TITLE
refactor: add public accessor methods to TimeRange classes

### DIFF
--- a/budget_forecaster/account/account_forecaster.py
+++ b/budget_forecaster/account/account_forecaster.py
@@ -61,7 +61,7 @@ class AccountForecaster:  # pylint: disable=too-few-public-methods
             if time_range.is_expired(balance_date):
                 continue
 
-            amount_per_day = operation_range.amount / time_range.duration.days
+            amount_per_day = operation_range.amount / time_range.total_duration.days
             budget_start_date = max(
                 time_range.initial_date, balance_date + timedelta(days=1)
             )

--- a/budget_forecaster/account/sqlite_repository.py
+++ b/budget_forecaster/account/sqlite_repository.py
@@ -1,6 +1,6 @@
 """SQLite repository for account data persistence."""
 
-# pylint: disable=protected-access,no-else-return
+# pylint: disable=no-else-return
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 
 import json
@@ -637,28 +637,20 @@ class SqliteRepository(RepositoryInterface):
         }
 
         if isinstance(time_range, PeriodicTimeRange):
-            # Get duration from initial time range (access private attribute)
-            # pylint: disable=protected-access
-            inner_range: TimeRange = (
-                time_range._PeriodicTimeRange__initial_time_range  # type: ignore
-            )
-            duration_rd: relativedelta = (
-                inner_range._TimeRange__duration  # type: ignore
-            )
-            dur_val, dur_unit = self._relativedelta_to_db(duration_rd)
+            # Get duration from base time range
+            dur_val, dur_unit = self._relativedelta_to_db(time_range.duration)
             result["duration_value"] = dur_val
             result["duration_unit"] = dur_unit
             # Get period
             per_val, per_unit = self._relativedelta_to_db(time_range.period)
             result["period_value"] = per_val
             result["period_unit"] = per_unit
-            # Get end date (access protected attribute)
-            if time_range._expiration_date != datetime.max:
-                result["end_date"] = time_range._expiration_date.isoformat()
+            # Get end date
+            if time_range.last_date != datetime.max:
+                result["end_date"] = time_range.last_date.isoformat()
         elif isinstance(time_range, TimeRange):
-            # Access the relativedelta duration (private attribute)
-            duration_rd = time_range._TimeRange__duration  # type: ignore[attr-defined]
-            dur_val, dur_unit = self._relativedelta_to_db(duration_rd)
+            # Get the relativedelta duration
+            dur_val, dur_unit = self._relativedelta_to_db(time_range.duration)
             result["duration_value"] = dur_val
             result["duration_unit"] = dur_unit
 
@@ -694,12 +686,12 @@ class SqliteRepository(RepositoryInterface):
         }
 
         if isinstance(time_range, PeriodicDailyTimeRange):
-            # period and _expiration_date are inherited from PeriodicTimeRange
-            per_val, per_unit = self._relativedelta_to_db(time_range._period)
+            # period is inherited from PeriodicTimeRange
+            per_val, per_unit = self._relativedelta_to_db(time_range.period)
             result["period_value"] = per_val
             result["period_unit"] = per_unit
-            if time_range._expiration_date != datetime.max:
-                result["end_date"] = time_range._expiration_date.isoformat()
+            if time_range.last_date != datetime.max:
+                result["end_date"] = time_range.last_date.isoformat()
 
         return result
 

--- a/budget_forecaster/operation_range/operation_range.py
+++ b/budget_forecaster/operation_range/operation_range.py
@@ -138,7 +138,7 @@ class OperationRange(OperationRangeInterface):
                 amount += self.amount
                 continue
 
-            amount_per_day = self.amount / time_range.duration.days
+            amount_per_day = self.amount / time_range.total_duration.days
             # incomplete period, two cases:
             # 1. time_range.initial_date < start_date
             # 2. time_range.last_date > end_date

--- a/budget_forecaster/tui/modals/budget_edit.py
+++ b/budget_forecaster/tui/modals/budget_edit.py
@@ -1,7 +1,7 @@
 """Budget edit modal for creating/editing budgets."""
 
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-# pylint: disable=protected-access,raise-missing-from,consider-using-assignment-expr
+# pylint: disable=raise-missing-from,consider-using-assignment-expr
 
 from datetime import datetime
 from typing import Any
@@ -204,11 +204,7 @@ class BudgetEditModal(ModalScreen[Budget | None]):
         if not self._budget:
             return 1
         tr = self._budget.time_range
-        if isinstance(tr, PeriodicTimeRange):
-            inner = tr._PeriodicTimeRange__initial_time_range  # type: ignore[attr-defined]
-            rd = inner._TimeRange__duration  # type: ignore[attr-defined]
-        else:
-            rd = tr._TimeRange__duration  # type: ignore[attr-defined]
+        rd = tr.duration
         return rd.months if rd.months else 1
 
     def _get_period_months(self) -> int | None:
@@ -217,7 +213,7 @@ class BudgetEditModal(ModalScreen[Budget | None]):
             return None
         tr = self._budget.time_range
         if isinstance(tr, PeriodicTimeRange):
-            return tr._period.months if tr._period.months else 1
+            return tr.period.months if tr.period.months else 1
         return None
 
     def _get_end_date(self) -> datetime | None:
@@ -226,8 +222,8 @@ class BudgetEditModal(ModalScreen[Budget | None]):
             return None
         tr = self._budget.time_range
         if isinstance(tr, PeriodicTimeRange):
-            if tr._expiration_date != datetime.max:
-                return tr._expiration_date
+            if tr.last_date != datetime.max:
+                return tr.last_date
         return None
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/budget_forecaster/tui/modals/planned_operation_edit.py
+++ b/budget_forecaster/tui/modals/planned_operation_edit.py
@@ -1,7 +1,7 @@
 """Planned operation edit modal for creating/editing planned operations."""
 
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-# pylint: disable=protected-access,raise-missing-from,no-else-return
+# pylint: disable=raise-missing-from,no-else-return
 # pylint: disable=consider-using-assignment-expr
 
 from datetime import datetime, timedelta
@@ -231,7 +231,7 @@ class PlannedOperationEditModal(ModalScreen[PlannedOperation | None]):
             return None
         tr = self._operation.time_range
         if isinstance(tr, PeriodicDailyTimeRange):
-            p = tr._period
+            p = tr.period
             if p.months:
                 return p.months
             elif p.days:
@@ -244,8 +244,8 @@ class PlannedOperationEditModal(ModalScreen[PlannedOperation | None]):
             return None
         tr = self._operation.time_range
         if isinstance(tr, PeriodicDailyTimeRange):
-            if tr._expiration_date != datetime.max:
-                return tr._expiration_date
+            if tr.last_date != datetime.max:
+                return tr.last_date
         return None
 
     def _get_hints(self) -> str:

--- a/budget_forecaster/tui/screens/budgets.py
+++ b/budget_forecaster/tui/screens/budgets.py
@@ -1,6 +1,6 @@
 """Budgets management screen for budget forecaster."""
 
-# pylint: disable=protected-access,no-else-return
+# pylint: disable=no-else-return
 
 import logging
 from datetime import datetime
@@ -135,15 +135,11 @@ class BudgetsWidget(Vertical):
 
             # Determine duration and periodicity
             if isinstance(time_range, PeriodicTimeRange):
-                # pylint: disable=protected-access
-                inner_range = (
-                    time_range._PeriodicTimeRange__initial_time_range  # type: ignore
-                )
-                duration = self._format_duration(inner_range)
-                period = self._format_period(time_range._period)
+                duration = self._format_duration(time_range.base_time_range)
+                period = self._format_period(time_range.period)
                 end_date = (
-                    time_range._expiration_date.strftime("%Y-%m-%d")
-                    if time_range._expiration_date != datetime.max
+                    time_range.last_date.strftime("%Y-%m-%d")
+                    if time_range.last_date != datetime.max
                     else "-"
                 )
             else:

--- a/budget_forecaster/tui/screens/planned_operations.py
+++ b/budget_forecaster/tui/screens/planned_operations.py
@@ -1,6 +1,6 @@
 """Planned operations management screen for budget forecaster."""
 
-# pylint: disable=protected-access,no-else-return
+# pylint: disable=no-else-return
 
 import logging
 from datetime import datetime
@@ -135,10 +135,10 @@ class PlannedOperationsWidget(Vertical):
 
             # Determine periodicity and end date
             if isinstance(time_range, PeriodicDailyTimeRange):
-                period = self._format_period(time_range._period)
+                period = self._format_period(time_range.period)
                 end_date = (
-                    time_range._expiration_date.strftime("%Y-%m-%d")
-                    if time_range._expiration_date != datetime.max
+                    time_range.last_date.strftime("%Y-%m-%d")
+                    if time_range.last_date != datetime.max
                     else "-"
                 )
             else:

--- a/tests/test_time_range.py
+++ b/tests/test_time_range.py
@@ -24,17 +24,26 @@ class TestTimeRange:
         """Test the last_date property."""
         assert time_range.last_date == datetime(2023, 1, 10)
 
-    def test_duration(self, time_range: TimeRange) -> None:
-        """Test the duration property."""
-        assert time_range.duration == timedelta(days=10)
+    def test_total_duration(self, time_range: TimeRange) -> None:
+        """Test the total_duration property."""
+        assert time_range.total_duration == timedelta(days=10)
 
-    def test_duration_relative(self) -> None:
-        """Test the duration property with a relative delta."""
+    def test_total_duration_relative(self) -> None:
+        """Test the total_duration property with a relative delta."""
         t_range = TimeRange(datetime(2023, 1, 1), relativedelta(months=1))
-        assert t_range.duration == timedelta(days=31)
+        assert t_range.total_duration == timedelta(days=31)
 
         t_range = TimeRange(datetime(2023, 2, 1), relativedelta(months=1))
-        assert t_range.duration == timedelta(days=28)
+        assert t_range.total_duration == timedelta(days=28)
+
+    def test_duration(self, time_range: TimeRange) -> None:
+        """Test the duration property returns the relativedelta."""
+        assert time_range.duration == relativedelta(days=10)
+
+    def test_duration_months(self) -> None:
+        """Test the duration property with months."""
+        t_range = TimeRange(datetime(2023, 1, 1), relativedelta(months=1))
+        assert t_range.duration == relativedelta(months=1)
 
     def test_contains_date_within_range(self, time_range: TimeRange) -> None:
         """Test the is_within method with dates within the range."""
@@ -93,7 +102,7 @@ class TestTimeRange:
         new_time_range = time_range.replace(initial_date=datetime(2023, 1, 2))
         assert new_time_range.initial_date == datetime(2023, 1, 2)
         assert new_time_range.last_date == datetime(2023, 1, 11)
-        assert new_time_range.duration == timedelta(days=10)
+        assert new_time_range.total_duration == timedelta(days=10)
 
 
 @pytest.fixture
@@ -105,17 +114,21 @@ def daily_time_range() -> DailyTimeRange:
 class TestDailyTimeRange:
     """Test cases for the DailyTimeRange class."""
 
-    def test_initial_date(self, time_range: TimeRange) -> None:
+    def test_initial_date(self, daily_time_range: DailyTimeRange) -> None:
         """Test the initial_date property."""
-        assert time_range.initial_date == datetime(2023, 1, 1)
+        assert daily_time_range.initial_date == datetime(2023, 1, 1)
 
-    def test_last_date(self, time_range: TimeRange) -> None:
+    def test_last_date(self, daily_time_range: DailyTimeRange) -> None:
         """Test the last_date property."""
-        assert time_range.last_date == datetime(2023, 1, 10)
+        assert daily_time_range.last_date == datetime(2023, 1, 1)
 
-    def test_duration(self, time_range: TimeRange) -> None:
-        """Test the duration property."""
-        assert time_range.duration == timedelta(days=10)
+    def test_total_duration(self, daily_time_range: DailyTimeRange) -> None:
+        """Test the total_duration property."""
+        assert daily_time_range.total_duration == timedelta(days=1)
+
+    def test_duration(self, daily_time_range: DailyTimeRange) -> None:
+        """Test the duration property returns the relativedelta."""
+        assert daily_time_range.duration == relativedelta(days=1)
 
     def test_contains_date_within_range(self, daily_time_range: DailyTimeRange) -> None:
         """Test the is_within method with dates within the range."""
@@ -180,7 +193,7 @@ class TestDailyTimeRange:
         new_time_range = daily_time_range.replace(initial_date=datetime(2023, 1, 2))
         assert new_time_range.initial_date == datetime(2023, 1, 2)
         assert new_time_range.last_date == datetime(2023, 1, 2)
-        assert new_time_range.duration == timedelta(days=1)
+        assert new_time_range.total_duration == timedelta(days=1)
 
 
 @pytest.fixture
@@ -191,7 +204,7 @@ def periodic_time_range(time_range: TimeRange) -> PeriodicTimeRange:
     )
 
 
-class TestPeriodicTimeRange:
+class TestPeriodicTimeRange:  # pylint: disable=too-many-public-methods
     """Test cases for the PeriodicTimeRange class."""
 
     def test_initial_date(self, periodic_time_range: PeriodicTimeRange) -> None:
@@ -202,9 +215,19 @@ class TestPeriodicTimeRange:
         """Test the last_date property."""
         assert periodic_time_range.last_date == datetime(2023, 12, 31)
 
+    def test_total_duration(self, periodic_time_range: PeriodicTimeRange) -> None:
+        """Test the total_duration property."""
+        assert periodic_time_range.total_duration == timedelta(days=365)
+
     def test_duration(self, periodic_time_range: PeriodicTimeRange) -> None:
-        """Test the duration property."""
-        assert periodic_time_range.duration == timedelta(days=365)
+        """Test the duration property returns the period's relativedelta."""
+        assert periodic_time_range.duration == relativedelta(days=10)
+
+    def test_base_time_range(self, periodic_time_range: PeriodicTimeRange) -> None:
+        """Test the base_time_range property."""
+        base = periodic_time_range.base_time_range
+        assert base.initial_date == datetime(2023, 1, 1)
+        assert base.duration == relativedelta(days=10)
 
     def test_contains_date_within_range(
         self, periodic_time_range: PeriodicTimeRange
@@ -329,4 +352,4 @@ class TestPeriodicTimeRange:
         new_time_range = periodic_time_range.replace(initial_date=datetime(2023, 1, 2))
         assert new_time_range.initial_date == datetime(2023, 1, 2)
         assert new_time_range.last_date == datetime(2023, 12, 31)
-        assert new_time_range.duration == timedelta(days=364)
+        assert new_time_range.total_duration == timedelta(days=364)


### PR DESCRIPTION
## Summary

- Add `total_duration` property (returns `timedelta`) to `TimeRangeInterface`
- Change `duration` property to return `relativedelta` instead of `timedelta`
- Add `base_time_range` property to `PeriodicTimeRange` to access the inner time range
- Update all code accessing private/mangled attributes (`_PeriodicTimeRange__initial_time_range`, `_TimeRange__duration`, `_expiration_date`, `_period`) to use public accessors

## Test plan

- [x] All 236 existing tests pass
- [x] Added new tests for `TimeRange.duration` (relativedelta)
- [x] Added new tests for `PeriodicTimeRange.base_time_range`
- [x] Pre-commit hooks pass (black, mypy, pylint, ruff)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)