### PR TITLE
docs: improve Claude commands with coding guidelines

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -61,11 +61,22 @@ git diff main...HEAD
 - No features added beyond what was specified
 - No over-engineering
 
+#### Codebase Coherence
+
+- **Uses existing abstractions?** If `RepositoryInterface` exists, new methods should be
+  added there, not bypass it with direct `SqliteRepository` usage
+- **Follows existing patterns?** Check similar features for naming, structure, DI
+  patterns
+- **No implementation leakage?** Dependencies should be on interfaces, not concrete
+  classes
+
 #### Testing Adequacy
 
 - Are there tests for new functionality?
 - Do tests validate actual behavior (not just "no exception")?
 - Are edge cases covered?
+- **Do tests test application logic, not Python built-ins?** Flag tests that verify
+  StrEnum values, NamedTuple iteration, dataclass fields, etc. These are useless.
 
 ### Step 4: Determine verdict
 
@@ -130,6 +141,8 @@ gh pr review <number> --comment --body "..."
 - "Missing test for the error path when file doesn't exist"
 - "The design specifies Y but this implements Z"
 - "Consider using a dataclass here for clarity"
+- "These tests are useless - they test Python's StrEnum/NamedTuple behavior, not your
+  code"
 
 ## Avoid
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ python -m budget_forecaster.main -c config.yaml categorize
 - pytest tests for any new feature
 - No dependencies not listed in setup.py
 - Always run tests (`pytest tests/`) before committing changes
+- **Prefer tuples over lists for return types** - Use `tuple[T, ...]` instead of
+  `list[T]` for function return values (tuples are immutable and signal that the caller
+  shouldn't modify the result)
 
 ## Data files (not versioned)
 


### PR DESCRIPTION
## Summary

- Add coding convention: prefer tuples over lists for return types
- Add guidelines for breaking down large features into multiple sub-PRs
- Add testing guidelines: don't test Python built-in features (StrEnum, NamedTuple, etc.)
- Add codebase coherence checks: use existing abstractions, follow patterns, no implementation leakage
- Add rule: never access private attributes or disable linter warnings for it

## Test plan

- [x] Documentation changes only, no code affected
- [x] Pre-commit hooks pass