### PR TITLE
docs: add design principles and improve PR workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -38,7 +38,20 @@ gh issue view <number>
 
 **Present this summary to the user before continuing.**
 
-#### Step 1.2: Read relevant code and check coherence (CRITICAL)
+#### Step 1.2: Check parent design (if applicable)
+
+If the issue mentions "Related to #X" or "Part of #X", **read the parent issue first**.
+The parent issue contains the overall design and specifies which methods/classes are
+actually needed. Don't add methods not in the design.
+
+```bash
+# Check if there's a parent design issue
+gh issue view <number> | grep -i "related to\|part of\|depends on"
+# If found, read it
+gh issue view <parent-number>
+```
+
+#### Step 1.3: Read relevant code and check coherence (CRITICAL)
 
 Check existing patterns in the codebase:
 
@@ -237,6 +250,7 @@ Phase 5: CREATE PR
 ## Tips
 
 - **When in doubt, check the design** - Don't add things not in the spec
+- **Read parent issues** - If "Related to #X", the parent has the full design
 - **Read before you code** - 10 minutes reading saves hours of rework
 - **Tests are deliverables** - A feature without tests is not complete
 - **Mark todos as you go** - Shows progress and ensures nothing is missed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,29 @@ python -m budget_forecaster.main -c config.yaml categorize
   `list[T]` for function return values (tuples are immutable and signal that the caller
   shouldn't modify the result)
 
+## Design principles
+
+- **Check the design before implementing** - Read linked issues (`Related to #X`) to
+  understand the full feature design. Don't add methods not specified in the design.
+
+- **Prefer domain objects over primitives** - Use `tuple[OperationLink, ...]` instead of
+  `dict[OperationId, IterationDate]`. Domain objects are more expressive and avoid
+  transformations.
+
+- **Single source of truth** - Don't maintain two representations of the same data
+  (e.g., a tuple AND an index dict). Pick one and derive the other if needed.
+
+- **Immutability by default** - Prefer immutable objects when the design allows. If an
+  object receives data at construction and doesn't need mutation methods, don't add
+  them.
+
+- **Simplify method signatures** - Accept domain objects directly
+  (`target: PlannedOperation | Budget`) rather than their decomposed parts
+  (`linked_type, linked_id, matcher`).
+
+- **Avoid redundant computations** - If you compute something in a loop, store it in the
+  result structure rather than recomputing it later.
+
 ## Data files (not versioned)
 
 - `*.xlsx` - BNP bank statements
@@ -84,8 +107,10 @@ When addressing PR review comments:
   `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -X POST -f body="..."`
 - **Never post global comments** summarizing changes - each comment deserves its own
   inline response
-- Reference commit hashes and issue numbers in replies (e.g., "✅ Fixed in commit
-  abc123" or "📝 Issue created: #42")
+- **Prefix replies with `🤖 Claude:`** to distinguish AI-generated responses from user
+  comments (since both appear under the same GitHub account)
+- Reference commit hashes and issue numbers in replies (e.g., "🤖 Claude: ✅ Fixed in
+  commit abc123" or "🤖 Claude: 📝 Issue created: #42")
 
 ## Creating GitHub issues
 


### PR DESCRIPTION
## Summary

- Add "Design principles" section to CLAUDE.md with lessons learned from PR #69
- Add step 1.2 "Check parent design" in /implement command
- Prefix PR replies with "🤖 Claude:" to distinguish AI-generated responses

## Changes

### CLAUDE.md
- New section "Design principles" covering:
  - Check the design before implementing
  - Prefer domain objects over primitives
  - Single source of truth
  - Immutability by default
  - Simplify method signatures
  - Avoid redundant computations
- Updated PR workflow to prefix replies with "🤖 Claude:"

### .claude/commands/implement.md
- New step 1.2 to check parent design issues
- Added tip about reading parent issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)