### PR TITLE
feat: add default UNCATEGORIZED category for imports

### DIFF
--- a/budget_forecaster/bank_adapter/bnp_paribas/bnp_paribas_bank_adapter.py
+++ b/budget_forecaster/bank_adapter/bnp_paribas/bnp_paribas_bank_adapter.py
@@ -145,7 +145,7 @@ class BnpParibasBankAdapter(BankAdapterBase):
                 return category
 
         self._unknown_categories.add(bnp_category)
-        return Category.OTHER
+        return Category.UNCATEGORIZED
 
     @property
     def unknown_categories(self) -> set[str]:

--- a/budget_forecaster/bank_adapter/swile/swile_bank_adapter.py
+++ b/budget_forecaster/bank_adapter/swile/swile_bank_adapter.py
@@ -57,7 +57,7 @@ class SwileBankAdapter(BankAdapterBase):
                         amount=Amount(
                             amount, transaction["amount"]["currency"]["iso_3"]
                         ),
-                        category=Category.OTHER,
+                        category=Category.UNCATEGORIZED,
                         date=date,
                     )
                 )

--- a/budget_forecaster/services/operation_service.py
+++ b/budget_forecaster/services/operation_service.py
@@ -48,7 +48,7 @@ class OperationFilter:
         if self.max_amount is not None and operation.amount > self.max_amount:
             return False
 
-        if self.uncategorized_only and operation.category != Category.OTHER:
+        if self.uncategorized_only and operation.category != Category.UNCATEGORIZED:
             return False
 
         return True
@@ -243,10 +243,10 @@ class OperationService:
         if not (similar := self.find_similar_operations(operation)):
             return None
 
-        # Find the most common category (excluding OTHER)
+        # Find the most common category (excluding UNCATEGORIZED)
         if not (
             categories := [
-                op.category for op in similar if op.category != Category.OTHER
+                op.category for op in similar if op.category != Category.UNCATEGORIZED
             ]
         ):
             return None

--- a/budget_forecaster/tui/screens/categorize.py
+++ b/budget_forecaster/tui/screens/categorize.py
@@ -325,7 +325,9 @@ class CategorizeScreen(Container):
         similar = self._service.find_similar_operations(
             self._current_operation, limit=20
         )
-        similar_ids = [op.unique_id for op in similar if op.category == Category.OTHER]
+        similar_ids = [
+            op.unique_id for op in similar if op.category == Category.UNCATEGORIZED
+        ]
 
         # Include current operation
         all_ids = [self._current_operation.unique_id, *similar_ids]

--- a/budget_forecaster/tui/screens/dashboard.py
+++ b/budget_forecaster/tui/screens/dashboard.py
@@ -225,6 +225,6 @@ class DashboardScreen(Container):
         categories_list.remove_children()
 
         for cat, amount in sorted_categories[:15]:  # Top 15 expenses
-            if cat != Category.OTHER or amount != 0:
+            if cat not in (Category.OTHER, Category.UNCATEGORIZED) or amount != 0:
                 row = CategoryRow(cat.value, amount, max_expense)
                 categories_list.mount(row)

--- a/budget_forecaster/types.py
+++ b/budget_forecaster/types.py
@@ -27,6 +27,9 @@ TargetName = str
 class Category(enum.StrEnum):
     """A category is a group of transactions."""
 
+    # Uncategorized (default for imports)
+    UNCATEGORIZED = "Non catégorisé"
+
     # Income
     SALARY = "Salaire"
     TAX_CREDIT = "Crédit d'impot"

--- a/tests/test_operation_service.py
+++ b/tests/test_operation_service.py
@@ -34,7 +34,7 @@ def sample_operations() -> tuple[HistoricOperation, ...]:
             unique_id=3,
             description="CARTE AMAZON",
             amount=Amount(-99.99),
-            category=Category.OTHER,
+            category=Category.UNCATEGORIZED,
             date=datetime(2025, 1, 20),
         ),
         HistoricOperation(
@@ -130,7 +130,7 @@ class TestOperationFilter:
         filter_ = OperationFilter(uncategorized_only=True)
         matches = [op for op in sample_operations if filter_.matches(op)]
         assert len(matches) == 1
-        assert matches[0].category == Category.OTHER
+        assert matches[0].category == Category.UNCATEGORIZED
 
 
 class TestOperationService:
@@ -169,10 +169,10 @@ class TestOperationService:
         assert operation is None
 
     def test_get_uncategorized_operations(self, service: OperationService) -> None:
-        """get_uncategorized_operations returns only OTHER category."""
+        """get_uncategorized_operations returns only UNCATEGORIZED category."""
         operations = service.get_uncategorized_operations()
         assert len(operations) == 1
-        assert operations[0].category == Category.OTHER
+        assert operations[0].category == Category.UNCATEGORIZED
 
     def test_update_operation_category(
         self, service: OperationService, mock_account_manager: MagicMock

--- a/tests/test_swile_bank_adapter.py
+++ b/tests/test_swile_bank_adapter.py
@@ -126,11 +126,11 @@ class TestSwileBankAdapterLoad:
         swile_adapter: SwileBankAdapter,
         operation_factory: HistoricOperationFactory,
     ) -> None:
-        """Test that all operations are categorized as OTHER."""
+        """Test that all operations are categorized as UNCATEGORIZED."""
         swile_adapter.load_bank_export(FIXTURES_DIR, operation_factory)
 
         for operation in swile_adapter.operations:
-            assert operation.category == Category.OTHER
+            assert operation.category == Category.UNCATEGORIZED
 
     def test_load_operations_currency(
         self,


### PR DESCRIPTION
## Summary

- Add new `UNCATEGORIZED = "Non catégorisé"` category to distinguish "not yet categorized" from "intentionally other"
- Bank adapters (BNP, Swile) now assign `UNCATEGORIZED` on import instead of `OTHER`
- Update `uncategorized_only` filter and TUI screens to use `UNCATEGORIZED`

## Test plan

- [x] All 306 tests pass
- [x] Pre-commit hooks pass
- [x] Manual test: import a bank statement and verify operations have `UNCATEGORIZED` category
- [x] Manual test: categorize screen shows only `UNCATEGORIZED` operations

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)