### PR TITLE
fix: apply late logic to planned operations without links

### DIFF
--- a/budget_forecaster/forecast/forecast_actualizer.py
+++ b/budget_forecaster/forecast/forecast_actualizer.py
@@ -259,26 +259,19 @@ class ForecastActualizer:  # pylint: disable=too-few-public-methods
         for planned_operation in sorted(
             planned_operations, key=lambda op: op.time_range.initial_date
         ):
-            if linked_iterations := self.__get_linked_iterations(planned_operation):
-                # Has links: check for late iterations (past iterations without links)
-                late_iterations = self.__get_late_iterations(
-                    planned_operation, linked_iterations
+            linked_iterations = self.__get_linked_iterations(planned_operation)
+            # Check for late iterations (past iterations without links)
+            late_iterations = self.__get_late_iterations(
+                planned_operation, linked_iterations
+            )
+            if late_iterations:
+                # Some iterations are late, postpone them to tomorrow
+                postponed = self.__handle_late_iterations(
+                    planned_operation, late_iterations
                 )
-                if late_iterations:
-                    # Some iterations are late, postpone them
-                    postponed = self.__handle_late_iterations(
-                        planned_operation, late_iterations
-                    )
-                    actualized_planned_operations.extend(postponed)
-                else:
-                    # No late iterations, use link-based actualization
-                    updated = self.__actualize_planned_operation_with_links(
-                        planned_operation, linked_iterations
-                    )
-                    if updated is not None:
-                        actualized_planned_operations.append(updated)
+                actualized_planned_operations.extend(postponed)
             else:
-                # No links: just advance to next period (no late logic)
+                # No late iterations, use link-based actualization
                 updated = self.__actualize_planned_operation_with_links(
                     planned_operation, linked_iterations
                 )


### PR DESCRIPTION
## Summary

- Fix regression where planned operations without manual links were incorrectly advanced to next period instead of being postponed to tomorrow when within tolerance window
- Always check for late iterations, regardless of whether links exist
- Add test for late operations within tolerance window

## Context

Operations within the tolerance window (default 5 days before balance date) should be considered "late" and postponed to tomorrow. This was working correctly before manual operation linking was introduced in commit 4d49f4b.

The bug caused salaries that hadn't arrived yet (but were within the 5-day tolerance) to be marked as "absent" instead of "late", resulting in incorrect actualized forecasts.

## Test plan

- [x] Run `pytest tests/test_forecast_actualizer.py` - all 14 tests pass
- [x] Run full test suite - all 348 tests pass
- [x] Manual verification: regenerate forecast and verify salaries within tolerance are correctly shown as actualized

🤖 Generated with [Claude Code](https://claude.com/claude-code)