### PR TITLE
docs: add rules for avoiding tautological tests and TUI integration

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -93,6 +93,65 @@ assert operations == (
 
 **Don't test language guarantees**: No need to test that NamedTuple is immutable, etc.
 
+## Avoid tautological tests
+
+Tests should verify behavior, not implementation. Avoid tests that:
+
+- Test `set.add()` / `set.clear()` / `list.append()` behavior
+- Mock internal methods just to call them directly
+- Verify that a method was called (mock assertions) without checking outcome
+
+```python
+# BAD - tests that set.add works
+def test_toggle_adds_to_set():
+    table._selected_ids.add(1)
+    assert 1 in table._selected_ids  # Tautological
+
+# BAD - excessive mocking to test private method
+def test_toggle_selection():
+    table.cursor_row = MagicMock(return_value=0)
+    table._toggle_selection(op_id=1, row_index=0)  # Testing internals
+    assert 1 in table._selected_ids
+
+# GOOD - test user-facing behavior
+async def test_toggle_selection_with_space():
+    async with app.run_test() as pilot:
+        await pilot.press("space")
+        assert table.selected_count == 1
+```
+
+## TUI integration tests with Textual
+
+For TUI features, use Textual's test framework instead of mocking:
+
+```python
+from textual.app import App, ComposeResult
+
+class TestApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield MyWidget()
+
+@pytest.mark.asyncio
+async def test_keyboard_shortcut():
+    app = TestApp()
+    async with app.run_test() as pilot:
+        widget = app.query_one(MyWidget)
+
+        # Simulate user input
+        await pilot.press("space")
+        await pilot.press("ctrl+a")
+
+        # Verify result
+        assert widget.state == expected
+```
+
+Benefits:
+
+- Tests real keyboard bindings
+- Catches event handling bugs
+- No mocking of internals
+- Documents actual user interactions
+
 ---
 
 For high-level testing principles, see `CLAUDE.md`.


### PR DESCRIPTION
## Summary

- Add guidance on avoiding tautological tests (testing `set.add()`, excessive mocking)
- Document Textual integration test pattern for TUI features with `app.run_test()`
- Provide concrete examples of bad vs good test patterns

## Context

Following the refactoring of `tests/test_operation_table.py` in PR #91, this documents the patterns to follow for future TUI tests.

## Test plan

- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)