### PR TITLE
fix: report actual imported operations count after DB filtering

### DIFF
--- a/budget_forecaster/account/account_interface.py
+++ b/budget_forecaster/account/account_interface.py
@@ -4,6 +4,7 @@ from typing import Protocol
 
 from budget_forecaster.account.account import Account, AccountParameters
 from budget_forecaster.operation_range.historic_operation import HistoricOperation
+from budget_forecaster.types import ImportStats
 
 
 class AccountInterface(Protocol):
@@ -19,8 +20,12 @@ class AccountInterface(Protocol):
         """Return the individual accounts."""
         ...
 
-    def upsert_account(self, account: AccountParameters) -> None:
-        """Add or update an account."""
+    def upsert_account(self, account: AccountParameters) -> ImportStats:
+        """Add or update an account.
+
+        Returns:
+            ImportStats with the number of new and duplicate operations.
+        """
         ...
 
     def replace_account(self, new_account: Account) -> None:

--- a/budget_forecaster/account/persistent_account.py
+++ b/budget_forecaster/account/persistent_account.py
@@ -4,6 +4,7 @@ from budget_forecaster.account.account import Account, AccountParameters
 from budget_forecaster.account.aggregated_account import AggregatedAccount
 from budget_forecaster.account.repository_interface import RepositoryInterface
 from budget_forecaster.operation_range.historic_operation import HistoricOperation
+from budget_forecaster.types import ImportStats
 
 
 class PersistentAccount:
@@ -48,11 +49,15 @@ class PersistentAccount:
             raise FileNotFoundError("No account found")
         return self._aggregated_account.accounts
 
-    def upsert_account(self, account: AccountParameters) -> None:
-        """Add or update an account."""
+    def upsert_account(self, account: AccountParameters) -> ImportStats:
+        """Add or update an account.
+
+        Returns:
+            ImportStats with the number of new and duplicate operations.
+        """
         if self._aggregated_account is None:
             raise FileNotFoundError("No account found")
-        self._aggregated_account.upsert_account(account)
+        return self._aggregated_account.upsert_account(account)
 
     def replace_account(self, new_account: Account) -> None:
         """Replace an existing account."""

--- a/budget_forecaster/types.py
+++ b/budget_forecaster/types.py
@@ -55,6 +55,19 @@ ImportProgressCallback = Callable[
 """Callback for import progress updates: (current, total, filename) -> None."""
 
 
+class ImportStats(NamedTuple):
+    """Statistics about an import operation."""
+
+    total_in_file: int
+    """Total number of operations in the imported file."""
+
+    new_operations: int
+    """Number of new operations added to the database."""
+
+    duplicates_skipped: int
+    """Number of duplicate operations that were already in the database."""
+
+
 class Category(enum.StrEnum):
     """A category is a group of transactions."""
 

--- a/tests/test_application_service.py
+++ b/tests/test_application_service.py
@@ -20,7 +20,7 @@ from budget_forecaster.services.import_service import ImportResult, ImportServic
 from budget_forecaster.services.operation_link_service import OperationLinkService
 from budget_forecaster.services.operation_service import OperationService
 from budget_forecaster.time_range import DailyTimeRange, TimeRange
-from budget_forecaster.types import Category, LinkType
+from budget_forecaster.types import Category, ImportStats, LinkType
 
 
 @pytest.fixture
@@ -134,7 +134,7 @@ class TestImportFile:
         mock_result = ImportResult(
             path=Path("/test.xlsx"),
             success=False,
-            operations_count=0,
+            stats=None,
             error_message="Test error",
         )
         mock_import_service.import_file.return_value = mock_result
@@ -159,7 +159,7 @@ class TestImportFile:
         mock_result = ImportResult(
             path=Path("/test.xlsx"),
             success=True,
-            operations_count=5,
+            stats=ImportStats(total_in_file=5, new_operations=5, duplicates_skipped=0),
         )
         mock_import_service.import_file.return_value = mock_result
 
@@ -188,7 +188,7 @@ class TestImportFile:
         mock_result = ImportResult(
             path=Path("/test.xlsx"),
             success=False,
-            operations_count=0,
+            stats=None,
             error_message="Failed",
         )
         mock_import_service.import_file.return_value = mock_result


### PR DESCRIPTION
## Summary

Fixes #38

When importing bank exports, now reports the actual number of **new** operations added vs duplicates skipped:

- Before: "150 operations imported" (misleading when many are duplicates)
- After: "20 nouvelles opérations, 130 doublons ignorés"

## Changes

- Add `ImportStats` NamedTuple with `total_in_file`, `new_operations`, `duplicates_skipped`
- `AggregatedAccount.update_account` now returns `UpdateResult` with stats
- Stats propagate through `PersistentAccount` → `ImportService` → TUI
- Convert `ImportResult` and `ImportSummary` to NamedTuples (per project convention)
- Update TUI to display detailed import results

## Test plan

- [x] All 342 tests pass
- [ ] Import a new file → shows "X nouvelles opérations"
- [ ] Re-import same file → shows "0 nouvelles, X doublons ignorés"

🤖 Generated with [Claude Code](https://claude.com/claude-code)