### PR TITLE
refactor: merge categorize_operation and bulk_categorize

### DIFF
--- a/budget_forecaster/tui/app.py
+++ b/budget_forecaster/tui/app.py
@@ -405,9 +405,8 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
         if category is None or not self._categorizing_operation_ids:
             return
 
-        # Use bulk_categorize for efficiency (works for single or multiple)
-        results = self.app_service.bulk_categorize(
-            list(self._categorizing_operation_ids), category
+        results = self.app_service.categorize_operations(
+            self._categorizing_operation_ids, category
         )
 
         if not results:

--- a/budget_forecaster/tui/screens/operations.py
+++ b/budget_forecaster/tui/screens/operations.py
@@ -202,7 +202,9 @@ class CategoryEditModal(ModalScreen[bool]):
     ) -> None:
         """Handle category selection."""
         if self._app_service:
-            self._app_service.categorize_operation(self._operation_id, event.category)
+            self._app_service.categorize_operations(
+                (self._operation_id,), event.category
+            )
             # Save changes
             # pylint: disable=import-outside-toplevel
             from budget_forecaster.tui.app import BudgetApp


### PR DESCRIPTION
## Summary

Fixes #92

Merges `categorize_operation(id, cat)` and `bulk_categorize(ids, cat)` into a single method:

```python
def categorize_operations(
    self, operation_ids: tuple[int, ...], category: Category
) -> tuple[OperationCategoryUpdate, ...]:
```

Caller passes 1-element tuple for single operation. Batch link creation optimized for all cases.

## Changes

- `ApplicationService`: Remove 2 methods, add 1 unified method
- `operations.py`: Update modal to use `categorize_operations((id,), cat)`
- `app.py`: Update bulk handler to use `categorize_operations(ids, cat)`
- Tests: Merge test classes, adapt assertions

## Test plan

- [x] All 342 tests pass
- [ ] Single operation categorization works
- [ ] Multi-selection categorization works

🤖 Generated with [Claude Code](https://claude.com/claude-code)