### PR TITLE
docs: reinforce that implementation workflow applies to all issues

### DIFF
--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -4,6 +4,8 @@
 
 **NEVER** start coding immediately. Follow this workflow:
 
+**This applies to ALL issues, including quick wins.** No exceptions.
+
 ### 1. Present the issue
 
 - Read and understand the issue


### PR DESCRIPTION
Clarifies that the implementation workflow (present plan → validate → implement) applies to ALL issues including quick wins.