### PR TITLE
feat: add include patterns for inbox filtering

### DIFF
--- a/budget_forecaster/config.py
+++ b/budget_forecaster/config.py
@@ -50,6 +50,7 @@ class Config:  # pylint: disable=too-few-public-methods
         # Import config (default to user's download directory)
         self.inbox_path = _get_user_download_dir()
         self.inbox_exclude_patterns: list[str] = []
+        self.inbox_include_patterns: list[str] = []
         # Logging config (native Python logging dictConfig format)
         self.logging_config: dict[str, Any] | None = None
 
@@ -66,6 +67,8 @@ class Config:  # pylint: disable=too-few-public-methods
                 self.inbox_path = Path(config["inbox_path"]).expanduser()
             if "inbox_exclude_patterns" in config:
                 self.inbox_exclude_patterns = config["inbox_exclude_patterns"] or []
+            if "inbox_include_patterns" in config:
+                self.inbox_include_patterns = config["inbox_include_patterns"] or []
             # Parse backup config
             if "backup" in config:
                 backup_cfg = config["backup"]

--- a/budget_forecaster/tui/app.py
+++ b/budget_forecaster/tui/app.py
@@ -185,6 +185,7 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
             self._persistent_account,
             self._config.inbox_path,
             self._config.inbox_exclude_patterns,
+            self._config.inbox_include_patterns,
         )
         forecast_service = ForecastService(
             self._persistent_account.account,


### PR DESCRIPTION
## Summary

- Add `inbox_include_patterns` config option to whitelist files in inbox
- If specified, only files matching at least one pattern are processed
- Exclude patterns still take precedence over include patterns

## Config example

```yaml
inbox:
  path: ./inbox
  exclude_patterns:
    - "*.tmp"
  include_patterns:
    - "BNP-*.xlsx"
    - "Swile-*.xlsx"
```

## Files modified

- `budget_forecaster/config.py` - Parse `inbox_include_patterns`
- `budget_forecaster/services/import_service.py` - Add `_should_include()` logic
- `budget_forecaster/tui/app.py` - Pass include patterns to ImportService
- `tests/test_import_service.py` - Tests for include patterns

Closes #43