### PR TITLE
fix(ci): skip coverage comment action on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Run tests with coverage
         run: pytest tests/ -v --cov --cov-report=term-missing
       - name: Coverage comment on PR
+        if: github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Fix CI failure on push to main after #114 merge.

The coverage comment action tries to store reference data in a branch but lacks write permissions on push events. Since coverage comments are only useful on PRs, skip the action when `github.event_name == 'push'`.

## Test plan

- [ ] CI passes on this PR
- [ ] CI will pass on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)