### PR TITLE
refactor: replace print with logging in SqliteRepository

### DIFF
--- a/budget_forecaster/account/sqlite_repository.py
+++ b/budget_forecaster/account/sqlite_repository.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-public-methods
 
 import json
+import logging
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -27,6 +28,8 @@ from budget_forecaster.time_range import (
     TimeRangeInterface,
 )
 from budget_forecaster.types import Category, LinkType, OperationId, TargetId
+
+logger = logging.getLogger(__name__)
 
 # Current schema version
 CURRENT_SCHEMA_VERSION = 3
@@ -180,7 +183,7 @@ class SqliteRepository(RepositoryInterface):
                     f"Invalid migration chain: {from_version} -> {target_version}"
                 )
 
-            print(f"Applying migration to schema version {target_version}...")
+            logger.info("Applying migration to schema version %d", target_version)
 
             if isinstance(migration, str):
                 conn.executescript(migration)
@@ -189,7 +192,7 @@ class SqliteRepository(RepositoryInterface):
 
             self._set_schema_version(target_version)
 
-        print(f"Database schema is at version {CURRENT_SCHEMA_VERSION}")
+        logger.info("Database schema is at version %d", CURRENT_SCHEMA_VERSION)
 
     def close(self) -> None:
         """Close the database connection."""


### PR DESCRIPTION
## Summary

- Add `logging` module import and create module-level logger
- Replace `print()` statements with `logger.info()` for migration messages
- Use `%d` formatting instead of f-strings (logging best practice)

## Test plan

- [x] All 346 tests pass
- [x] Pre-commit hooks pass

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)