### PR TITLE
refactor: simplify ForecastService.compute_report type narrowing

### DIFF
--- a/budget_forecaster/services/forecast_service.py
+++ b/budget_forecaster/services/forecast_service.py
@@ -204,11 +204,7 @@ class ForecastService:
         Returns:
             The computed AccountAnalysisReport.
         """
-        if self._forecast is None:
-            self.load_forecast()
-
-        # After load_forecast(), _forecast is guaranteed to be set
-        assert self._forecast is not None
+        forecast = self._forecast or self.load_forecast()
 
         if start_date is None:
             start_date = date.today() - relativedelta(months=4)
@@ -217,7 +213,7 @@ class ForecastService:
 
         logger.info("Computing forecast report from %s to %s", start_date, end_date)
 
-        analyzer = AccountAnalyzer(self._account, self._forecast, operation_links)
+        analyzer = AccountAnalyzer(self._account, forecast, operation_links)
         self._report = analyzer.compute_report(
             datetime.combine(start_date, time()),
             datetime.combine(end_date, time()),


### PR DESCRIPTION
## Summary

- Use the return value of `load_forecast()` instead of a defensive assert
- Eliminates dead code while still satisfying mypy's type narrowing

**Before:**
```python
if self._forecast is None:
    self.load_forecast()
assert self._forecast is not None  # Dead code for type narrowing
```

**After:**
```python
forecast = self._forecast or self.load_forecast()
```

## Test plan

- [x] All 25 forecast_service tests pass
- [x] Pre-commit hooks pass (mypy, pylint, black)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)