### PR TITLE
chore: replace personal email with GitHub noreply address

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = budget_forecaster
 description = Budget analyzer with forecast feature
 author = Corentin Corgié
-author_email = corentin.corgie@gmail.com
+author_email = 110186540+corentin-core@users.noreply.github.com
 classifiers = Python Programming Language: Python :: 3 :: Only
 
 [options]


### PR DESCRIPTION
## Summary

- Replace personal Gmail address with GitHub noreply email in `setup.cfg`

## Context

Preparation for making the repository public.

🤖 Generated with [Claude Code](https://claude.ai/code)