### PR TITLE
refactor: replace if/else with match statements for LinkType checks

### DIFF
--- a/budget_forecaster/tui/modals/link_target.py
+++ b/budget_forecaster/tui/modals/link_target.py
@@ -171,8 +171,12 @@ class LinkTargetModal(
         self._selected_target: PlannedOperation | Budget | None = None
 
         # Set initial type based on current link
-        if current_link and current_link.target_type == LinkType.BUDGET:
-            self._current_type = "budget"
+        if current_link:
+            match current_link.target_type:
+                case LinkType.BUDGET:
+                    self._current_type = "budget"
+                case LinkType.PLANNED_OPERATION:
+                    self._current_type = "planned"
         else:
             self._current_type = "planned"
 
@@ -232,14 +236,15 @@ class LinkTargetModal(
             return ""
 
         target_id = self._current_link.target_id
-        if self._current_link.target_type == LinkType.PLANNED_OPERATION:
-            for op in self._planned_operations:
-                if op.id == target_id:
-                    return op.description
-        else:
-            for budget in self._budgets:
-                if budget.id == target_id:
-                    return budget.description
+        match self._current_link.target_type:
+            case LinkType.PLANNED_OPERATION:
+                for op in self._planned_operations:
+                    if op.id == target_id:
+                        return op.description
+            case LinkType.BUDGET:
+                for budget in self._budgets:
+                    if budget.id == target_id:
+                        return budget.description
 
         # Fallback to ID if not found
         return f"#{target_id}"


### PR DESCRIPTION
## Summary

- Convert 2 remaining `if/else` patterns checking `LinkType` enum to `match` statements
- Aligns with the rest of the codebase which already uses `match` for `LinkType` checks
- Enables exhaustiveness checking by the type checker

## Changes

In `budget_forecaster/tui/modals/link_target.py`:
- `__init__`: Convert initial type selection based on current link
- `_get_current_link_name`: Convert target lookup by link type

## Test plan

- [x] All 446 existing tests pass
- [x] Pre-commit hooks pass (mypy, pylint, etc.)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)