### PR TITLE
fix: resolve datetime-to-date regression from #177

### DIFF
--- a/budget_forecaster/default_config.yaml
+++ b/budget_forecaster/default_config.yaml
@@ -6,3 +6,18 @@ backup:
   enabled: true
   max_backups: 5
   directory: ~/.local/share/budget-forecaster/backups/
+# logging:  # Override default logging (~/.local/share/budget-forecaster/budget-forecaster.log)
+#   version: 1
+#   disable_existing_loggers: false
+#   handlers:
+#     file:
+#       class: logging.FileHandler
+#       filename: /absolute/path/to/custom.log
+#       level: DEBUG
+#       formatter: default
+#   formatters:
+#     default:
+#       format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+#   root:
+#     level: DEBUG
+#     handlers: [file]

--- a/budget_forecaster/infrastructure/config.py
+++ b/budget_forecaster/infrastructure/config.py
@@ -86,12 +86,19 @@ class Config:  # pylint: disable=too-few-public-methods
                 self.logging_config = config["logging"]
 
     def setup_logging(self) -> None:
-        """Initialize Python's logging system using the configuration."""
+        """Initialize Python's logging system using the configuration.
+
+        When no logging config is provided, logs to
+        ``~/.local/share/budget-forecaster/budget-forecaster.log`` at INFO level.
+        """
         if not self.logging_config:
-            # Default basic configuration
+            log_dir = Path.home() / ".local" / "share" / "budget-forecaster"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            log_file = log_dir / "budget-forecaster.log"
             logging.basicConfig(
                 level=logging.INFO,
                 format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                filename=str(log_file),
             )
         else:
             try:

--- a/budget_forecaster/services/account/account_analyzer.py
+++ b/budget_forecaster/services/account/account_analyzer.py
@@ -305,12 +305,11 @@ class AccountAnalyzer:
                 expenses_per_category_dict.setdefault(operation.category, []).append(
                     (operation.operation_date, operation.amount)
                 )
-        expenses_per_category = {
-            category: pd.DataFrame(expenses, columns=["Date", "Montant"]).set_index(
-                "Date"
-            )
-            for category, expenses in expenses_per_category_dict.items()
-        }
+        expenses_per_category = {}
+        for category, expenses in expenses_per_category_dict.items():
+            df = pd.DataFrame(expenses, columns=["Date", "Montant"])
+            df["Date"] = pd.to_datetime(df["Date"])
+            expenses_per_category[category] = df.set_index("Date")
 
         df = pd.DataFrame(
             {


### PR DESCRIPTION
## Summary

- Add DB migration v4: convert datetime strings (`T00:00:00`) to date strings in all timestamp columns
- Fix pandas `resample` in `compute_budget_statistics` by converting `date` index to `DatetimeIndex`
- Add default file logging to `~/.local/share/budget-forecaster/budget-forecaster.log`

## Test plan

- [x] New migration test: creates a v3 DB with datetime strings, runs migration, verifies all columns are converted
- [x] All 476 tests pass
- [x] Manually verified TUI loads and computes forecast without error