### PR TITLE
refactor: eliminate unloaded state in PersistentAccount

### DIFF
--- a/budget_forecaster/services/import_service.py
+++ b/budget_forecaster/services/import_service.py
@@ -191,7 +191,7 @@ class ImportService:
             self._persistent_account.save()
 
             # Reload to get updated operations with unique_ids
-            self._persistent_account.load()
+            self._persistent_account.reload()
 
             if move_to_processed:
                 self._move_to_processed(path)

--- a/budget_forecaster/tui/app.py
+++ b/budget_forecaster/tui/app.py
@@ -183,8 +183,8 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
             backup_service.rotate_backups()
 
         repository = SqliteRepository(self._config.database_path)
+        repository.initialize()
         self._persistent_account = PersistentAccount(repository)
-        self._persistent_account.load()
 
         # Create individual services
         operation_service = OperationService(self._persistent_account)
@@ -329,7 +329,7 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
     def action_refresh_data(self) -> None:
         """Refresh data from the database."""
         if self._persistent_account is not None:
-            self._persistent_account.load()
+            self._persistent_account.reload()
             self._refresh_screens()
 
     def save_changes(self) -> None:
@@ -367,7 +367,7 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
         if event.success:
             # Reload data from database and refresh all screens
             if self._persistent_account:
-                self._persistent_account.load()
+                self._persistent_account.reload()
             self._refresh_screens()
 
     def _on_file_selected(self, path: Path | None) -> None:
@@ -437,7 +437,7 @@ class BudgetApp(App[None]):  # pylint: disable=too-many-instance-attributes
         self.save_changes()
         # Reload data from database and refresh all screens
         if self._persistent_account:
-            self._persistent_account.load()
+            self._persistent_account.reload()
         self._refresh_screens()
 
         # Clear selection in all tables

--- a/tests/infrastructure/persistence/test_persistent_account.py
+++ b/tests/infrastructure/persistence/test_persistent_account.py
@@ -199,13 +199,11 @@ class TestSqliteRepository:
 class TestPersistentAccount:
     """Tests for the PersistentAccount class."""
 
-    def test_load_raises_when_no_account(self, temp_db_path: Path) -> None:
-        """Test that load raises AccountNotLoadedError when no account exists."""
+    def test_constructor_raises_when_no_account(self, temp_db_path: Path) -> None:
+        """Test that constructor raises AccountNotLoadedError when no account exists."""
         with SqliteRepository(temp_db_path) as repository:
-            persistent = PersistentAccount(repository)
-
             with pytest.raises(AccountNotLoadedError):
-                persistent.load()
+                PersistentAccount(repository)
 
     def test_save_and_load(self, temp_db_path: Path, sample_account: Account) -> None:
         """Test saving and loading an aggregated account."""
@@ -217,20 +215,11 @@ class TestPersistentAccount:
         # Load through PersistentAccount
         with SqliteRepository(temp_db_path) as repository2:
             persistent = PersistentAccount(repository2)
-            persistent.load()
 
             assert persistent.account.name == "Mes comptes"
             assert len(persistent.accounts) == 1
             assert persistent.accounts[0].name == "Compte courant"
             assert len(persistent.accounts[0].operations) == 3
-
-    def test_account_raises_when_not_loaded(self, temp_db_path: Path) -> None:
-        """Test that accessing account raises when not loaded."""
-        with SqliteRepository(temp_db_path) as repository:
-            persistent = PersistentAccount(repository)
-
-            with pytest.raises(AccountNotLoadedError):
-                _ = persistent.account
 
     def test_upsert_account(self, temp_db_path: Path, sample_account: Account) -> None:
         """Test upserting account through the interface."""
@@ -242,7 +231,6 @@ class TestPersistentAccount:
         # Load, modify via upsert, save
         with SqliteRepository(temp_db_path) as repository:
             persistent = PersistentAccount(repository)
-            persistent.load()
 
             new_operation = HistoricOperation(
                 unique_id=4,
@@ -264,7 +252,6 @@ class TestPersistentAccount:
         # Reload and verify
         with SqliteRepository(temp_db_path) as repository2:
             persistent2 = PersistentAccount(repository2)
-            persistent2.load()
 
             account = persistent2.accounts[0]
             assert len(account.operations) == 4

--- a/tests/services/operation/test_operation_link_service.py
+++ b/tests/services/operation/test_operation_link_service.py
@@ -420,7 +420,6 @@ class TestApplicationServiceLinkIntegration:
         repository.upsert_account(account)
 
         persistent = PersistentAccount(repository)
-        persistent.load()
         return persistent
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

- Load eagerly in `__init__` instead of two-phase construct-then-load
- Rename `load()` to `reload()` to reflect actual usage at call sites
- Remove `_aggregated_account: AggregatedAccount | None` — always `AggregatedAccount`
- Remove all 5 guard clauses (dead code)
- Move `repository.initialize()` to caller (`BudgetApp._load_config`)

## Test plan

- [x] All 472 existing tests pass
- [x] All pre-commit hooks pass (mypy, pylint, ruff, black)
- [ ] CI passes

Closes #190