### PR TITLE
fix: bootstrap account on empty database startup

### DIFF
--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -3,6 +3,17 @@
 The application uses YAML configuration. A default configuration file is created on
 first run at `~/.config/budget-forecaster/config.yaml`.
 
+## Default Paths
+
+| Resource      | Default path                                             |
+| ------------- | -------------------------------------------------------- |
+| Configuration | `~/.config/budget-forecaster/config.yaml`                |
+| Database      | `~/.local/share/budget-forecaster/budget.db`             |
+| Log file      | `~/.local/share/budget-forecaster/budget-forecaster.log` |
+| Backups       | `~/.local/share/budget-forecaster/backups/`              |
+
+All paths can be customized in the configuration file (see below).
+
 ## Configuration Structure
 
 ```yaml
@@ -65,4 +76,7 @@ set the path explicitly.
 
 The `logging` section accepts Python's
 [dictConfig format](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema).
-If omitted or invalid, the application falls back to basic `INFO`-level console logging.
+When no logging configuration is provided, the application logs to
+`~/.local/share/budget-forecaster/budget-forecaster.log` at `INFO` level. If the
+provided configuration is invalid, the application falls back to basic `DEBUG`-level
+console logging.

--- a/tests/tui/test_app_bootstrap.py
+++ b/tests/tui/test_app_bootstrap.py
@@ -1,0 +1,29 @@
+"""Tests for BudgetApp bootstrap with empty database."""
+
+from pathlib import Path
+
+import pytest
+
+from budget_forecaster.tui.app import BudgetApp
+
+
+@pytest.fixture
+def empty_db_config(tmp_path: Path) -> Path:
+    """Create a minimal config pointing to a non-existent database."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"database_path: {tmp_path / 'empty.db'}\n"
+        "account_name: Test Account\n"
+        "account_currency: EUR\n"
+    )
+    return config_path
+
+
+@pytest.mark.asyncio
+async def test_app_starts_with_empty_database(empty_db_config: Path) -> None:
+    """App should bootstrap an account from config when DB is empty."""
+    app = BudgetApp(config_path=empty_db_config)
+    async with app.run_test():
+        service = app.app_service
+        assert service.balance == 0.0
+        assert service.currency == "EUR"


### PR DESCRIPTION
## Summary

- When starting with an empty database, the app now creates an initial account using values from the config (`account_name`, `account_currency`) instead of exiting silently with `AccountNotLoadedError`
- Documents default paths (config, database, logs, backups) in `docs/dev/configuration.md`
- Fixes incorrect logging fallback description (was "console logging", actually logs to file)

Closes #138

## Test plan

- [x] New async test verifies BudgetApp starts with empty DB and creates account with correct balance/currency
- [x] Full test suite passes (612 tests)
- [ ] Manual test: delete DB file, start app, verify it opens normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)