### PR TITLE
fix: include zero-months in budget statistics average

### DIFF
--- a/budget_forecaster/services/account/account_analyzer.py
+++ b/budget_forecaster/services/account/account_analyzer.py
@@ -305,6 +305,8 @@ class AccountAnalyzer:
             else analysis_end
         )
 
+        all_months = pd.date_range(analysis_start, analysis_end, freq="MS")
+
         for operation in self._account.operations:
             if analysis_start <= operation.operation_date <= analysis_end:
                 expenses_per_category_dict.setdefault(operation.category, []).append(
@@ -321,7 +323,10 @@ class AccountAnalyzer:
                 "Catégorie": list(expenses_per_category),
                 "Total": [df["Montant"].sum() for df in expenses_per_category.values()],
                 "Moyenne mensuelle": [
-                    df.resample("MS")["Montant"].sum().mean()
+                    df.resample("MS")["Montant"]
+                    .sum()
+                    .reindex(all_months, fill_value=0.0)
+                    .mean()
                     for df in expenses_per_category.values()
                 ],
             }


### PR DESCRIPTION
## Summary

- Fix `compute_budget_statistics()` monthly average inflated by omitting months with no operations
- Reindex resampled series over the full analysis period with `fill_value=0.0` so empty months count in the denominator
- Add test validating zero-month inclusion in the average

## Test plan

- [x] Existing statistics tests still pass (5/5)
- [x] New test `test_zero_months_included_in_average` validates the fix
- [x] Full test suite passes (612/612)

Closes #201