### PR TITLE
feat: rename Actualisé to Ajusté in UI and docs

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -2,6 +2,7 @@ abc
 abstractmethod
 acount
 actualisé
+ajusté
 al
 alimentation
 args

--- a/budget_forecaster/services/account/account_analyzer.py
+++ b/budget_forecaster/services/account/account_analyzer.py
@@ -195,7 +195,7 @@ class AccountAnalyzer:
                 increment_expense(
                     operation.category,
                     operation.operation_date.replace(day=1),
-                    "Actualisé",
+                    "Ajusté",
                     operation.amount,
                 )
 
@@ -239,7 +239,7 @@ class AccountAnalyzer:
         df.columns = df.columns.swaplevel(0, 1)  # type: ignore[attr-defined]
         df.sort_index(axis=1, level=0, inplace=True)
 
-        # Filter out "Actualisé" columns for dates before the current balance date
+        # Filter out "Ajusté" columns for dates before the current balance date
         df = df.loc[
             :,
             (df.columns.get_level_values(0) >= current_month)
@@ -247,7 +247,7 @@ class AccountAnalyzer:
             | (df.columns.get_level_values(1) == "Prévu"),
         ]
 
-        # Filter out "Réel" and "Actualisé" columns for dates after the current balance date
+        # Filter out "Réel" and "Ajusté" columns for dates after the current balance date
         df = df.loc[
             :,
             (df.columns.get_level_values(0) <= current_month)

--- a/budget_forecaster/services/forecast/forecast_service.py
+++ b/budget_forecaster/services/forecast/forecast_service.py
@@ -277,8 +277,8 @@ class ForecastService:
                     else 0
                 )
                 actualized = (
-                    df.loc[category, (month, "Actualisé")]
-                    if (month, "Actualisé") in df.columns
+                    df.loc[category, (month, "Ajusté")]
+                    if (month, "Ajusté") in df.columns
                     else 0
                 )
 

--- a/budget_forecaster/tui/modals/split_operation.py
+++ b/budget_forecaster/tui/modals/split_operation.py
@@ -162,7 +162,7 @@ class SplitOperationModal(ModalScreen[SplitResult | None]):
                         classes="form-input",
                     )
                 yield Static(
-                    "ⓘ Prochaine itération non actualisée",
+                    "ⓘ Prochaine itération non ajustée",
                     classes="info-hint",
                 )
 

--- a/budget_forecaster/tui/screens/forecast.py
+++ b/budget_forecaster/tui/screens/forecast.py
@@ -138,7 +138,7 @@ class ForecastWidget(Vertical):
         with Vertical(id="tables-container"):
             yield Static("Budget par catégorie", classes="section-title")
             yield Static(
-                "R = Réel | A = Actualisé | P = Prévu",
+                "R = Réel | A = Ajusté | P = Prévu",
                 id="table-legend",
             )
             yield DataTable(id="budget-table")
@@ -372,14 +372,14 @@ class ForecastWidget(Vertical):
         table.add_column("Catégorie", key="category")
 
         # Build column structure from DataFrame columns
-        # Columns are (month, type) tuples where type is "Réel", "Prévu", or "Actualisé"
+        # Columns are (month, type) tuples where type is "Réel", "Prévu", or "Ajusté"
         columns_info: list[tuple] = []  # (month, type, column_key, column_label)
 
         for col in df.columns:
             month = col[0]  # pandas Timestamp
-            col_type = str(col[1])  # "Réel", "Prévu", or "Actualisé"
+            col_type = str(col[1])  # "Réel", "Prévu", or "Ajusté"
             month_str = month.strftime("%Y-%m")  # type: ignore[attr-defined]
-            type_abbrev = {"Réel": "R", "Prévu": "P", "Actualisé": "A"}.get(
+            type_abbrev = {"Réel": "R", "Prévu": "P", "Ajusté": "A"}.get(
                 col_type, col_type[0]
             )
             col_key = f"{month_str}_{type_abbrev}"
@@ -387,7 +387,7 @@ class ForecastWidget(Vertical):
             columns_info.append((month, col_type, col_key, col_label))
 
         # Sort columns by month then by type order (R, A, P)
-        type_order = {"Réel": 0, "Actualisé": 1, "Prévu": 2}
+        type_order = {"Réel": 0, "Ajusté": 1, "Prévu": 2}
         columns_info.sort(key=lambda x: (x[0], type_order.get(x[1], 3)))
 
         # Add columns to table

--- a/docs/user/forecast.md
+++ b/docs/user/forecast.md
@@ -139,7 +139,7 @@ For each budget, the forecast tracks consumption:
 
 - **Planned**: The full budget amount for the period
 - **Actual** (Réel): Sum of real bank operations linked to this budget
-- **Actualized** (Actualisé): Projected spending for the current period based on links
+- **Adjusted** (Ajusté): Projected spending for the current period based on links
 - **Remaining**: Budget amount minus linked operations
 
 ### Daily Projection (Linear Decrease)
@@ -192,11 +192,11 @@ If linked operations exceed the budget, the remaining amount goes negative (over
 
 The forecast report includes a monthly summary with three columns per month:
 
-| Column                     | Meaning                                                       |
-| -------------------------- | ------------------------------------------------------------- |
-| **Réel** (Actual)          | Sum of real bank operations for that month                    |
-| **Prévu** (Planned)        | Sum of planned operations and budgets for that month          |
-| **Actualisé** (Actualized) | Projected amounts for the current month, accounting for links |
+| Column                | Meaning                                                       |
+| --------------------- | ------------------------------------------------------------- |
+| **Réel** (Actual)     | Sum of real bank operations for that month                    |
+| **Prévu** (Planned)   | Sum of planned operations and budgets for that month          |
+| **Ajusté** (Adjusted) | Projected amounts for the current month, accounting for links |
 
 - Past months only show **Réel** and **Prévu**
 - The current month shows all three columns
@@ -207,7 +207,7 @@ The forecast report includes a monthly summary with three columns per month:
 The forecast report can be exported to Excel from the Forecast tab. The export includes:
 
 - Balance evolution chart
-- Monthly summary by category (Réel / Prévu / Actualisé)
+- Monthly summary by category (Réel / Prévu / Ajusté)
 - Budget statistics (total and monthly average per category)
 
 ## Tips

--- a/docs/user/operation-links.md
+++ b/docs/user/operation-links.md
@@ -176,7 +176,7 @@ The modal displays a match score (0-100%) for each target to help you choose.
 
 When an operation is linked to a planned operation iteration:
 
-- The iteration is marked as **actualized** and excluded from future forecasts
+- The iteration is marked as **adjusted** and excluded from future forecasts
 - The actual amount replaces the planned amount for balance calculations
 - Other operations won't automatically match this iteration
 

--- a/docs/user/tui-planned-budgets.md
+++ b/docs/user/tui-planned-budgets.md
@@ -85,7 +85,7 @@ When you split an operation or budget:
 │ └─────────────────────────────────────────────────────────┘   │
 │                                                               │
 │ Première itération:  [ 2025-06-01 ]                           │
-│ (i) Prochaine itération non actualisée                        │
+│ (i) Prochaine itération non ajustée                           │
 │ ───────────────────────────────────────────────────────────── │
 │ Montant:             [ 2700.0     ]                           │
 │ Période:             [ Mensuel   v]                           │
@@ -144,7 +144,7 @@ For budgets, an additional **Durée** field is displayed:
 
 ## Tips
 
-- **Default split date**: The modal suggests the next non-actualized iteration (first
+- **Default split date**: The modal suggests the next non-adjusted iteration (first
   future iteration without a linked operation)
 - **Preserve history**: Use split instead of edit when you want to keep historical
   values for reporting

--- a/tests/services/account/test_account_analyzer.py
+++ b/tests/services/account/test_account_analyzer.py
@@ -302,7 +302,7 @@ class TestComputeBudgetForecast:
         planned_operations: tuple[PlannedOperation, ...],
         budgets: tuple[Budget, ...],
     ) -> None:
-        """Expenses per category and month have Réel, Prévu, and Actualisé columns."""
+        """Expenses per category and month have Réel, Prévu, and Ajusté columns."""
         analyzer = AccountAnalyzer(account, Forecast(planned_operations, budgets))
         df = analyzer.compute_budget_forecast(date(2023, 1, 1), date(2023, 5, 1))
         assert df.loc[str(Category.GROCERIES)]["2023-01-01"]["Réel"] == -50.0
@@ -311,10 +311,10 @@ class TestComputeBudgetForecast:
         assert df.loc[str(Category.GROCERIES)]["2023-03-01"]["Prévu"] == -320.0
         assert df.loc[str(Category.CAR_FUEL)]["2023-03-01"]["Prévu"] == 0.0
         assert df.loc[str(Category.OTHER)]["2023-03-01"]["Prévu"] == -50.0
-        # "Actualisé" = after actualization: planned op advanced to April
-        assert df.loc[str(Category.GROCERIES)]["2023-03-01"]["Actualisé"] == -300.0
-        assert df.loc[str(Category.CAR_FUEL)]["2023-03-01"]["Actualisé"] == 0.0
-        assert df.loc[str(Category.OTHER)]["2023-03-01"]["Actualisé"] == -50.0
+        # "Ajusté" = after actualization: planned op advanced to April
+        assert df.loc[str(Category.GROCERIES)]["2023-03-01"]["Ajusté"] == -300.0
+        assert df.loc[str(Category.CAR_FUEL)]["2023-03-01"]["Ajusté"] == 0.0
+        assert df.loc[str(Category.OTHER)]["2023-03-01"]["Ajusté"] == -50.0
         assert df.loc[str(Category.GROCERIES)]["2023-04-01"]["Prévu"] == -320.0
         assert df.loc[str(Category.CAR_FUEL)]["2023-04-01"]["Prévu"] == 0.0
         assert df.loc[str(Category.OTHER)]["2023-04-01"]["Prévu"] == -250.0

--- a/tests/services/forecast/test_forecast_service.py
+++ b/tests/services/forecast/test_forecast_service.py
@@ -452,7 +452,7 @@ class TestGetMonthlySummary:
             [
                 (month, "Réel"),
                 (month, "Prévu"),
-                (month, "Actualisé"),
+                (month, "Ajusté"),
             ]
         )
         df = pd.DataFrame(

--- a/tests/services/use_cases/test_compute_forecast_use_case.py
+++ b/tests/services/use_cases/test_compute_forecast_use_case.py
@@ -98,7 +98,7 @@ class TestComputeReportIntegration:
 
         Expected:
         - The March planned op iteration is marked as actualized (linked)
-        - The "Actualisé" column for March reflects only the remaining
+        - The "Ajusté" column for March reflects only the remaining
           unlinked planned operations (none here), not the linked one
         """
         historic_op = HistoricOperation(
@@ -179,9 +179,9 @@ class TestComputeReportIntegration:
         assert budget_forecast.loc[str(Category.OTHER)]["2025-03-01"]["Réel"] == -95.0
 
         # The linked planned op is actualized: the March iteration is consumed
-        # by the link, so "Actualisé" reflects the actual amount from the link
+        # by the link, so "Ajusté" reflects the actual amount from the link
         march_actualized = budget_forecast.loc[str(Category.OTHER)]["2025-03-01"][
-            "Actualisé"
+            "Ajusté"
         ]
         # Without link, March planned op would be advanced (not executed).
         # With link, it's recognized as actualized: the forecast shows the linked


### PR DESCRIPTION
## Summary

- Rename user-facing term "Actualisé" → "Ajusté" across TUI, Excel export, and documentation
- The triplet **Réel / Prévu / Ajusté** is more intuitive than "Actualisé"
- Internal code (`ForecastActualizer`, `CategoryBudget.actualized`, etc.) remains unchanged — no user-visible impact

## Changes

**Source (4 files):** DataFrame column name, TUI legend/abbreviations, split modal hint
**Tests (3 files):** Updated string references to match new column name
**User docs (3 files):** forecast.md, tui-planned-budgets.md, operation-links.md
**Other:** `.custom.dic` updated by pylint spell checker

## Test plan

- [x] All 611 tests pass
- [x] All pre-commit hooks pass
- [x] No remaining "Actualisé" in source, tests, or user docs
- [ ] Manual: verify TUI forecast screen shows "R = Réel | A = Ajusté | P = Prévu"
- [ ] Manual: verify Excel export uses "Ajusté" column header

Closes #141