### PR TITLE
fix: remove obsolete datetime index conversion in Excel export

### DIFF
--- a/budget_forecaster/services/account/account_analysis_renderer.py
+++ b/budget_forecaster/services/account/account_analysis_renderer.py
@@ -105,11 +105,7 @@ class AccountAnalysisRendererExcel(AccountAnalysisRenderer):
     def _add_operations(self, operations: pd.DataFrame) -> None:
         sheet_name = "Opérations"
 
-        # hack: we can't set multiple date formats in the same workbook
-        # convert datetime to date to avoid the datetime format
         operations_reformatted = operations.copy()
-        idx = operations_reformatted.index
-        operations_reformatted.index = idx.date  # type: ignore[attr-defined]
         operations_reformatted.index.name = "Date"
         operations_reformatted = operations_reformatted.sort_index(ascending=False)
 

--- a/tests/services/account/test_account_analysis_renderer.py
+++ b/tests/services/account/test_account_analysis_renderer.py
@@ -28,7 +28,7 @@ def sample_report() -> AccountAnalysisReport:
             "Description": ["CARREFOUR", "VIREMENT SALAIRE", "CINEMA"],
             "Montant": [-85.20, 2500.00, -15.00],
         },
-        index=pd.DatetimeIndex(
+        index=pd.Index(
             [date(2025, 1, 10), date(2025, 1, 11), date(2025, 1, 12)],
             name="Date",
         ),
@@ -202,7 +202,7 @@ class TestAccountAnalysisRendererExcel:
             end_date=date(2025, 3, 31),
             operations=pd.DataFrame(
                 columns=["Catégorie", "Description", "Montant"],
-                index=pd.DatetimeIndex([], name="Date"),
+                index=pd.Index([], dtype="object", name="Date"),
             ),
             forecast=pd.DataFrame(
                 columns=["Montant", "Date début", "Date fin"],


### PR DESCRIPTION
## Summary

- Remove `idx.date` call in `_add_operations` that assumed a `DatetimeIndex` — after the datetime→date refactor (PR #177), the index contains `date` objects directly
- Fix test fixtures to use `pd.Index` with `date` objects instead of `pd.DatetimeIndex`, matching actual production behavior

## Root cause

Commit c034723 (PR #177) converted all `datetime` to `date` throughout the codebase but missed updating `_add_operations` which still called `.date` on the index. The existing tests didn't catch it because they used `DatetimeIndex` in fixtures.

## Test plan

- [x] Test fails without the production fix (verified: `AttributeError: 'Index' object has no attribute 'date'`)
- [x] Test passes with the fix
- [x] Full test suite passes (612 tests)