### PR TITLE
chore: setup project for public release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ venv
 agent-os/
 implementation-progress.md
 site/
+.coverage
+coverage.xml
+.serena/
+*.xlsx

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Corentin Corgié
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,21 @@
 [metadata]
 name = budget_forecaster
+version = 0.1.0
 description = Budget analyzer with forecast feature
 author = Corentin Corgié
 author_email = 110186540+corentin-core@users.noreply.github.com
-classifiers = Python Programming Language: Python :: 3 :: Only
+license = MIT
+license_files = LICENSE
+url = https://github.com/corentin-core/budget-forecaster
+project_urls =
+    Documentation = https://corentin-core.github.io/budget-forecaster/
+    Repository = https://github.com/corentin-core/budget-forecaster
+    Issues = https://github.com/corentin-core/budget-forecaster/issues
+classifiers =
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Topic :: Office/Business :: Financial
 
 [options]
 packages = find:


### PR DESCRIPTION
## Summary

- Add MIT license
- Add version 0.1.0, project URLs, license field, and classifiers to `setup.cfg`
- Update `.gitignore` to exclude coverage files, `.serena/`, and `*.xlsx` forecasts

## Manual steps after merge

- Branch protection on `main`
- Set repo visibility to Public
- Pin repo + description + topics
- Create `v0.1.0` GitHub release
- Profile README

Closes #10