### PR TITLE
fix: pin all dependency versions for stable CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,17 +23,17 @@ install_requires =
     openpyxl==3.1.5
     matplotlib==3.10.0
     xlrd==2.0.1
-    pyyaml
-    pandas
-    xlsxwriter
-    textual>=0.47.0
+    pyyaml==6.0.3
+    pandas==3.0.0
+    xlsxwriter==3.2.9
+    textual==7.4.0
 
 [options.extras_require]
 dev =
-    pytest
-    pytest-asyncio
-    pytest-cov
-    pylint-pytest
+    pytest==8.2.0
+    pytest-asyncio==1.3.0
+    pytest-cov==7.0.0
+    pylint-pytest==1.1.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## Summary

Pin all unpinned dependencies to their current working versions. Fixes mypy CI failure caused by textual 8.0.0 (released today) changing the type signature of `Select.BLANK`.

## Changes

**Runtime deps** — pinned to current installed versions:
- `pyyaml` → `==6.0.3`
- `pandas` → `==3.0.0`
- `xlsxwriter` → `==3.2.9`
- `textual>=0.47.0` → `==7.4.0`

**Dev deps** — pinned to current installed versions:
- `pytest` → `==8.2.0`
- `pytest-asyncio` → `==1.3.0`
- `pytest-cov` → `==7.0.0`
- `pylint-pytest` → `==1.1.8`

Already pinned (unchanged): `openpyxl==3.1.5`, `matplotlib==3.10.0`, `xlrd==2.0.1`

## Root cause

CI runs `mypy --install-types --non-interactive` which installs the latest textual. With `textual>=0.47.0`, pip resolves to 8.0.0 where `Select.BLANK` changed type, breaking mypy on `operations.py:347`.