### PR TITLE
ci: add Codecov integration

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -13,6 +13,7 @@ bool
 budgetinterface
 cancelled
 cli
+codecov
 commun
 config
 conn
@@ -32,6 +33,7 @@ dicts
 dir
 edf
 enum
+gettext
 historicoperation
 impl
 iterable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,11 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Run tests with coverage
-        run: pytest tests/ -v --cov --cov-report=term-missing
-      - name: Coverage comment on PR
-        if: github.event_name == 'pull_request'
-        uses: py-cov-action/python-coverage-comment-action@v3
+        run: pytest tests/ -v --cov --cov-report=term-missing --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
         with:
-          GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 80
-          MINIMUM_ORANGE: 60
-          ANNOTATE_MISSING_LINES: true
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/corentin-core/budget-forecaster/actions/workflows/ci.yml/badge.svg)](https://github.com/corentin-core/budget-forecaster/actions/workflows/ci.yml)
 [![Docs](https://github.com/corentin-core/budget-forecaster/actions/workflows/docs.yml/badge.svg)](https://corentin-core.github.io/budget-forecaster/)
+[![codecov](https://codecov.io/gh/corentin-core/budget-forecaster/graph/badge.svg)](https://codecov.io/gh/corentin-core/budget-forecaster)
 ![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)
 ![mypy strict](https://img.shields.io/badge/mypy-strict-blue)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        informational: true
+    patch:
+      default:
+        target: 90%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

- Replace `py-cov-action/python-coverage-comment-action` with `codecov/codecov-action@v5`
- Add `codecov.yml` with project target (80%) and patch target (90%), both informational
- Add Codecov badge to README

## Notes

- The second commit adds a dummy test to trigger Codecov's PR comment — **to be reverted before merge**
- Codecov must be enabled on the repo at https://codecov.io (no token needed for public repos)

## Test plan

- [ ] CI passes and uploads coverage to Codecov
- [ ] Codecov posts a PR comment with coverage diff
- [ ] Badge renders correctly in README

Closes #115