### PR TITLE
docs: add blog article link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ connections, but none could forecast my balance the way I needed, and their budg
 management was too limited.
 
 So I built my own.
+[Read the full story on my blog.](https://corentin-core.github.io/posts/budget-forecaster/)
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Add link to the blog article telling the full story behind budget-forecaster in the "Why" section of the README

## Test plan

- [ ] Link points to the correct article URL