### PR TITLE
feat: add CodSpeed benchmarks for report generation

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -16,6 +16,7 @@ cancelled
 cancelling
 cli
 codecov
+codspeed
 commun
 config
 conn
@@ -69,12 +70,14 @@ pragma
 pre
 prs
 prévu
+pytest
 recomputation
 recurringdaterange
 relativedelta
 renderable
 renderer
 renderers
+repo
 repr
 reproducibility
 revenus

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,4 +30,5 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
+          mode: simulation
           run: pytest tests/benchmarks/ --codspeed

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,33 @@
+name: CodSpeed Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "budget_forecaster/core/**"
+      - "budget_forecaster/domain/**"
+      - "budget_forecaster/services/**"
+      - "budget_forecaster/infrastructure/persistence/**"
+      - "tests/benchmarks/**"
+      - ".github/workflows/codspeed.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          run: pytest tests/benchmarks/ --codspeed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/corentin-core/budget-forecaster/actions/workflows/ci.yml/badge.svg)](https://github.com/corentin-core/budget-forecaster/actions/workflows/ci.yml)
 [![Docs](https://github.com/corentin-core/budget-forecaster/actions/workflows/docs.yml/badge.svg)](https://corentin-core.github.io/budget-forecaster/)
 [![codecov](https://codecov.io/gh/corentin-core/budget-forecaster/graph/badge.svg)](https://codecov.io/gh/corentin-core/budget-forecaster)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/corentin-core/budget-forecaster)
 ![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)
 ![mypy strict](https://img.shields.io/badge/mypy-strict-blue)
 

--- a/examples/generate_demo.py
+++ b/examples/generate_demo.py
@@ -869,6 +869,39 @@ def _generate_exports(bnp_balance: float, swile_balance: float) -> tuple[Path, P
 # ---------------------------------------------------------------------------
 # Main generation logic
 # ---------------------------------------------------------------------------
+def generate_demo_db(
+    db_path: Path,
+    account_name: str = "My Budget",
+    seed: int | None = None,
+) -> None:
+    """Populate a SQLite database with demo data (no file exports).
+
+    Useful for benchmarks and tests that need a realistic dataset.
+
+    Args:
+        db_path: Path for the SQLite database file.
+        account_name: Name for the aggregated account.
+        seed: Random seed for reproducibility. Also resets the ID counter.
+    """
+    global ID_COUNTER  # pylint: disable=global-statement
+    if seed is not None:
+        random.seed(seed)
+        ID_COUNTER = itertools.count(1)
+    repo = SqliteRepository(db_path)
+    repo.initialize()
+    repo.set_aggregated_account_name(account_name)
+
+    planned_op_ids, past_one_time_id, _future_one_time_id = _create_planned_operations(
+        repo
+    )
+    budget_ids = _create_budgets(repo)
+    all_bnp_ops, all_swile_ops, links = _generate_history(
+        planned_op_ids, past_one_time_id, budget_ids
+    )
+    _save_accounts(repo, all_bnp_ops, all_swile_ops, links)
+    repo.close()
+
+
 def main() -> None:
     """Generate all demo artifacts."""
     # Clean up existing files

--- a/examples/generate_demo.py
+++ b/examples/generate_demo.py
@@ -881,12 +881,10 @@ def generate_demo_db(
     Args:
         db_path: Path for the SQLite database file.
         account_name: Name for the aggregated account.
-        seed: Random seed for reproducibility. Also resets the ID counter.
+        seed: Random seed for reproducibility.
     """
-    global ID_COUNTER  # pylint: disable=global-statement
     if seed is not None:
         random.seed(seed)
-        ID_COUNTER = itertools.count(1)
     repo = SqliteRepository(db_path)
     repo.initialize()
     repo.set_aggregated_account_name(account_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ dev =
     pytest-cov==7.0.0
     pylint-pytest==1.1.8
     pyenchant==3.3.0
+    pytest-codspeed==4.3.0
 
 [options.entry_points]
 console_scripts =

--- a/tests/benchmarks/test_report_benchmark.py
+++ b/tests/benchmarks/test_report_benchmark.py
@@ -1,0 +1,114 @@
+"""Benchmarks for report generation pipeline.
+
+Uses the demo data generator to create a realistic dataset, then benchmarks
+the most expensive computations in the report pipeline.
+
+Run locally (validation only, no measurements):
+    pytest tests/benchmarks/ --codspeed
+
+Actual measurements happen in CI via CodSpeed's instrumented runner.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from dateutil.relativedelta import relativedelta
+
+from budget_forecaster.domain.account.account import Account
+from budget_forecaster.domain.forecast.forecast import Forecast
+from budget_forecaster.domain.operation.operation_link import OperationLink
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+from budget_forecaster.services.account.account_analyzer import AccountAnalyzer
+from budget_forecaster.services.forecast.forecast_service import ForecastService
+from examples.generate_demo import generate_demo_db
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def demo_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a temporary demo database for benchmarks."""
+    db_path = tmp_path_factory.mktemp("bench") / "bench.db"
+    generate_demo_db(db_path, account_name="Benchmark", seed=42)
+    return db_path
+
+
+@pytest.fixture(scope="module")
+def pipeline(
+    demo_db: Path,
+) -> tuple[PersistentAccount, ForecastService, tuple[OperationLink, ...]]:
+    """Set up the full pipeline from DB: repo -> account -> forecast service."""
+    repo = SqliteRepository(demo_db)
+    repo.initialize()
+    persistent_account = PersistentAccount(repo)
+    service = ForecastService(persistent_account, repo)
+    service.load_forecast()
+    links = repo.get_all_links()
+    return persistent_account, service, links
+
+
+@pytest.fixture(scope="module")
+def analyzer_inputs(
+    pipeline: tuple[PersistentAccount, ForecastService, tuple[OperationLink, ...]],
+) -> tuple[Account, Forecast, tuple[OperationLink, ...], date, date]:
+    """Prepare inputs for direct AccountAnalyzer benchmarks."""
+    persistent_account, service, links = pipeline
+    account = persistent_account.account
+    forecast = service.load_forecast()
+
+    start_date = date.today() - relativedelta(months=4)
+    end_date = date.today() + relativedelta(months=12)
+    return account, forecast, links, start_date, end_date
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_compute_report(
+    benchmark: pytest.BenchmarkFixture,
+    pipeline: tuple[PersistentAccount, ForecastService, tuple[OperationLink, ...]],
+) -> None:
+    """Benchmark the full report pipeline (end-to-end)."""
+    _, service, links = pipeline
+
+    benchmark(service.compute_report, operation_links=links)
+
+
+@pytest.mark.benchmark
+def test_compute_budget_forecast(
+    benchmark: pytest.BenchmarkFixture,
+    analyzer_inputs: tuple[Account, Forecast, tuple[OperationLink, ...], date, date],
+) -> None:
+    """Benchmark compute_budget_forecast — the most expensive sub-computation.
+
+    Involves 6+ passes over data, dict accumulation, and pandas MultiIndex reshaping.
+    """
+    account, forecast, links, start_date, end_date = analyzer_inputs
+    analyzer = AccountAnalyzer(account, forecast, links)
+
+    benchmark(analyzer.compute_budget_forecast, start_date, end_date)
+
+
+@pytest.mark.benchmark
+def test_compute_balance_evolution(
+    benchmark: pytest.BenchmarkFixture,
+    analyzer_inputs: tuple[Account, Forecast, tuple[OperationLink, ...], date, date],
+) -> None:
+    """Benchmark compute_balance_evolution_per_day — day-by-day simulation."""
+    account, forecast, links, start_date, end_date = analyzer_inputs
+    analyzer = AccountAnalyzer(account, forecast, links)
+
+    benchmark(analyzer.compute_balance_evolution_per_day, start_date, end_date)


### PR DESCRIPTION
## Summary

- Add `pytest-codspeed==4.3.0` to dev dependencies
- Create 3 benchmarks for the report generation pipeline using demo data:
  - `test_compute_report` — full end-to-end pipeline (~108ms)
  - `test_compute_budget_forecast` — most expensive sub-computation (~51ms)
  - `test_compute_balance_evolution` — day-by-day simulation (~41ms)
- Add `.github/workflows/codspeed.yml` with path filters (services, domain, core, persistence)
- Extract `generate_demo_db()` public function from `generate_demo.py` for reuse

## Test plan

- [x] Benchmarks pass locally with `pytest tests/benchmarks/ --codspeed`
- [x] Existing tests unaffected (860 passed)
- [ ] CodSpeed picks up the benchmarks on this PR (repo connected on codspeed.io)
- [ ] CodSpeed comments on the PR with benchmark results