### PR TITLE
perf: pre-compute operation dates in balance evolution loop

### DIFF
--- a/budget_forecaster/services/account/account_analyzer.py
+++ b/budget_forecaster/services/account/account_analyzer.py
@@ -190,11 +190,13 @@ class AccountAnalyzer:
         current_balance = initial_state.balance
         balance_evolution: list[float] = [current_balance]
         dates = pd.date_range(start_date, end_date, freq="D")
+
+        amount_by_date: defaultdict[date, float] = defaultdict(float)
+        for operation in final_state.operations:
+            amount_by_date[operation.operation_date] += operation.amount
+
         for ts in dates[1:]:
-            current_date = ts.date()
-            for operation in final_state.operations:
-                if operation.operation_date == current_date:
-                    current_balance += operation.amount
+            current_balance += amount_by_date[ts.date()]
             balance_evolution.append(current_balance)
 
         df = pd.DataFrame({"Date": dates, "Balance": balance_evolution})


### PR DESCRIPTION
## Summary

- Pre-compute a `defaultdict(float)` of amounts keyed by operation date before the day-by-day loop
- Eliminates repeated traversal of the `operation_date` property chain (3 layers: `HistoricOperation.operation_date` → `OperationRange.date_range` → `DateRange.start_date`)
- Reduces complexity from O(days × operations) to O(days + operations)

## Test plan

- [x] All 22 `test_account_analyzer.py` tests pass
- [ ] CodSpeed benchmark confirms >30% improvement on `test_compute_balance_evolution`
- [ ] No regression on `test_compute_report` or `test_compute_budget_forecast`

Closes #277