### PR TITLE
fix: exclude past dates from available margin

### DIFF
--- a/budget_forecaster/services/forecast/forecast_service.py
+++ b/budget_forecaster/services/forecast/forecast_service.py
@@ -531,8 +531,14 @@ class ForecastService:  # pylint: disable=too-many-public-methods
 
         balance_at_start = float(future_df["Balance"].iloc[0])
 
-        # Reverse expanding minimum: lowest balance from each day onward
-        balances = future_df["Balance"]
+        # For lowest balance, only consider today onward (past dips are irrelevant)
+        today_str = date.today().strftime("%Y-%m-%d")
+        from_str = max(month_str, today_str)
+        from_today_df = df.loc[df.index >= from_str]
+        if from_today_df.empty:
+            return None
+
+        balances = from_today_df["Balance"]
         lowest_balance = float(balances.min())
         lowest_idx = cast(pd.Timestamp, balances.idxmin())
         lowest_date = lowest_idx.to_pydatetime().date()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ dev =
     pylint-pytest==1.1.8
     pyenchant==3.3.0
     pytest-codspeed==4.3.0
+    freezegun==1.5.1
 
 [options.entry_points]
 console_scripts =

--- a/tests/services/forecast/test_margin.py
+++ b/tests/services/forecast/test_margin.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from freezegun import freeze_time
 
 from budget_forecaster.domain.account.account import Account
 from budget_forecaster.infrastructure.persistence.repository_interface import (
@@ -193,6 +194,34 @@ class TestGetAvailableMargin:
         assert result["available_margin"] == 2000
         assert result["balance_at_month_start"] == 2500
         assert result["lowest_balance_date"] == date(2026, 4, 15)
+
+    @freeze_time("2026-03-28")
+    @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
+    def test_excludes_past_dates_from_lowest_balance(
+        self,
+        mock_analyzer_class: MagicMock,
+        service: ForecastService,
+    ) -> None:
+        """Lowest balance ignores past dates within the current month."""
+        balance_df = _build_balance_df(
+            {
+                "2026-03-01": 3000,
+                "2026-03-24": 1000,  # past dip (before today 03-28)
+                "2026-03-28": 2500,
+                "2026-04-01": 2000,
+                "2026-04-15": 1800,
+            }
+        )
+        _compute_with_balance(service, mock_analyzer_class, balance_df)
+
+        result = service.get_available_margin(date(2026, 3, 1), threshold=0)
+
+        assert result is not None
+        # Past dip at 1000 on 03-24 should be ignored
+        assert result["lowest_balance"] == 1800
+        assert result["lowest_balance_date"] == date(2026, 4, 15)
+        # balance_at_start still reflects month start
+        assert result["balance_at_month_start"] == 3000
 
     @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
     def test_returns_none_for_empty_future(


### PR DESCRIPTION
## Summary

- The available margin in the review tab could show a past date as the "lowest future balance" (e.g., March 24 when today is March 28)
- Root cause: `get_available_margin()` searched for the minimum balance from the month start, not from today
- Fix: use `max(month_start, today)` as the lower bound for the lowest balance search
- Added `freezegun` test dependency for time-dependent test

## Test plan

- [x] New test `test_excludes_past_dates_from_lowest_balance` with frozen time
- [x] All 864 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)