### PR TITLE
fix: anchor balance chart on a zero baseline

### DIFF
--- a/budget_forecaster/tui/screens/balance.py
+++ b/budget_forecaster/tui/screens/balance.py
@@ -17,6 +17,79 @@ from budget_forecaster.tui.symbols import DisplaySymbol
 logger = logging.getLogger(__name__)
 
 
+def _render_ascii_chart(  # pylint: disable=too-many-locals
+    data: list[tuple[date, float]], width: int = 70, height: int = 8
+) -> list[str]:
+    """Render an ASCII area chart anchored on a zero baseline.
+
+    Bars grow up from zero for positive balances and down from zero for
+    negative ones. Zero is always inside the visible range so the sign of
+    the balance and any crossing into the red stay readable.
+    """
+    if not data:
+        return [_("No data")]
+
+    values = [v for _d, v in data]
+    # Always keep zero in range so negative balances read as bars below it.
+    low = min(0.0, *values)
+    high = max(0.0, *values)
+
+    # Round to nice multiples of 100€ for Y-axis
+    min_val = (low // 100) * 100
+    max_val = ((high // 100) + 1) * 100
+    val_range = max_val - min_val if max_val != min_val else 100
+
+    # Fixed Y-axis label width
+    y_label_width = 12
+
+    # Sample data to fit width
+    step = max(1, len(data) // width)
+    display_data = [data[i] for i in range(0, len(data), step)]
+
+    lines = []
+
+    # Half the vertical span a single row covers, used for band overlap so
+    # bars stay continuous even when no row lands exactly on zero.
+    half_cell = val_range / (height - 1) / 2
+
+    # Chart body with Y-axis labels
+    for row in range(height - 1, -1, -1):
+        y_value = min_val + (val_range * row / (height - 1))
+        y_rounded = round(y_value / 100) * 100
+        y_label = f"{y_rounded:>10,.0f} {DisplaySymbol.EURO}"
+
+        line_chars = []
+        for _d, val in display_data:
+            # Fill the row if the zero-to-value span overlaps this row's band.
+            # Every column's span touches zero, so the row nearest zero fills
+            # across all columns and reads as the baseline.
+            if min(0.0, val) <= y_value + half_cell and max(0.0, val) >= (
+                y_value - half_cell
+            ):
+                line_chars.append("█")
+            else:
+                line_chars.append(" ")
+        lines.append(f"{y_label} │{''.join(line_chars)}")
+
+    # X-axis line
+    chart_len = len(display_data)
+    lines.append(" " * y_label_width + " └" + DisplaySymbol.SEPARATOR * chart_len)
+
+    # X-axis with dates - simple format below the chart
+    if len(display_data) >= 2:
+        first_date = display_data[0][0].strftime("%m/%Y")
+        last_date = display_data[-1][0].strftime("%m/%Y")
+        mid_idx = len(display_data) // 2
+        mid_date = display_data[mid_idx][0].strftime("%m/%Y")
+
+        # Build date line with proper spacing
+        spacing = max(1, (chart_len - 21) // 2)  # 21 = 3 dates * 7 chars
+        date_line = f"{first_date}{' ' * spacing}{mid_date}{' ' * spacing}{last_date}"
+        lines.append(" " * (y_label_width + 2) + date_line)
+
+    return lines
+
+
 class BalanceWidget(Vertical):
     """Balance tab: chart showing balance evolution over time."""
 
@@ -163,72 +236,10 @@ class BalanceWidget(Vertical):
         # Use available widget dimensions (minus border/padding)
         chart_height = max(8, chart.content_size.height - 2)  # -2 for axis + date line
         chart_width = max(20, chart.content_size.width - 15)  # -15 for Y-axis labels
-        chart_lines = self._render_ascii_chart(
+        chart_lines = _render_ascii_chart(
             balance_data, width=chart_width, height=chart_height
         )
         chart.update("\n".join(chart_lines))
-
-    def _render_ascii_chart(  # pylint: disable=too-many-locals
-        self, data: list[tuple[date, float]], width: int = 70, height: int = 8
-    ) -> list[str]:
-        """Render a simple ASCII line chart with axes."""
-        if not data:
-            return [_("No data")]
-
-        values = [v for _d, v in data]
-        raw_min = min(values)
-        raw_max = max(values)
-
-        # Round to nice multiples of 100€ for Y-axis
-        min_val = (raw_min // 100) * 100
-        max_val = ((raw_max // 100) + 1) * 100
-        val_range = max_val - min_val if max_val != min_val else 100
-
-        # Fixed Y-axis label width
-        y_label_width = 12
-
-        # Sample data to fit width
-        step = max(1, len(data) // width)
-        display_data = [data[i] for i in range(0, len(data), step)]
-
-        lines = []
-
-        # Chart body with Y-axis labels
-        for row in range(height - 1, -1, -1):
-            y_value = min_val + (val_range * row / (height - 1))
-            y_rounded = round(y_value / 100) * 100
-            y_label = f"{y_rounded:>10,.0f} {DisplaySymbol.EURO}"
-
-            threshold = y_value
-            line_chars = []
-            for _d, val in display_data:
-                if val >= threshold:
-                    line_chars.append("█")
-                elif val >= threshold - (val_range / height / 2):
-                    line_chars.append("▄")
-                else:
-                    line_chars.append(" ")
-            lines.append(f"{y_label} │{''.join(line_chars)}")
-
-        # X-axis line
-        chart_len = len(display_data)
-        lines.append(" " * y_label_width + " └" + DisplaySymbol.SEPARATOR * chart_len)
-
-        # X-axis with dates - simple format below the chart
-        if len(display_data) >= 2:
-            first_date = display_data[0][0].strftime("%m/%Y")
-            last_date = display_data[-1][0].strftime("%m/%Y")
-            mid_idx = len(display_data) // 2
-            mid_date = display_data[mid_idx][0].strftime("%m/%Y")
-
-            # Build date line with proper spacing
-            spacing = max(1, (chart_len - 21) // 2)  # 21 = 3 dates * 7 chars
-            date_line = (
-                f"{first_date}{' ' * spacing}{mid_date}{' ' * spacing}{last_date}"
-            )
-            lines.append(" " * (y_label_width + 2) + date_line)
-
-        return lines
 
     def on_resize(self) -> None:
         """Re-render chart when widget is resized."""

--- a/tests/tui/test_balance_widget.py
+++ b/tests/tui/test_balance_widget.py
@@ -8,7 +8,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Button
 
 from budget_forecaster.tui.modals.export_forecast import ExportForecastModal
-from budget_forecaster.tui.screens.balance import BalanceWidget
+from budget_forecaster.tui.screens.balance import BalanceWidget, _render_ascii_chart
 
 
 class BalanceTestApp(App[None]):
@@ -158,3 +158,44 @@ async def test_export_button_opens_modal() -> None:
         assert any(
             isinstance(screen, ExportForecastModal) for screen in app.screen_stack
         )
+
+
+def _chart_body(lines: list[str]) -> list[str]:
+    """Keep only the chart-body rows (those with a Y-axis label and a bar area)."""
+    return [line for line in lines if "│" in line]
+
+
+class TestRenderAsciiChart:
+    """Zero-baseline behavior of the balance chart."""
+
+    def test_zero_axis_present_with_negative_values(self) -> None:
+        """A balance that goes negative keeps a labeled 0 line on the axis."""
+        data = [
+            (date(2025, 1, 1), 500.0),
+            (date(2025, 2, 1), -300.0),
+            (date(2025, 3, 1), -800.0),
+        ]
+        lines = _render_ascii_chart(data)
+        assert any(line.strip().startswith("0 ") for line in lines)
+
+    def test_negative_only_range_spans_zero(self) -> None:
+        """All-negative data still puts zero at the top and the min below it."""
+        data = [
+            (date(2025, 1, 1), -100.0),
+            (date(2025, 2, 1), -250.0),
+        ]
+        lines = _render_ascii_chart(data)
+        labels = [line.split("│")[0] for line in _chart_body(lines)]
+        assert any("0 " in label for label in labels)
+        assert any("-300" in label.replace(",", "") for label in labels)
+
+    def test_positive_bars_grow_from_bottom(self) -> None:
+        """With only positive data the zero baseline sits at the bottom row."""
+        data = [
+            (date(2025, 1, 1), 200.0),
+            (date(2025, 2, 1), 900.0),
+        ]
+        body = _chart_body(_render_ascii_chart(data))
+        # Bottom body row is fully filled (the zero baseline), top row is not.
+        assert "█" in body[-1].split("│")[1]
+        assert body[0].split("│")[1].strip() != body[-1].split("│")[1].strip()


### PR DESCRIPTION
## Context

The balance evolution chart (Balance tab) did not convey negative balances. It drew bars filled from the bottom of the visible range, with the baseline set to the data minimum and no zero reference. A negative balance rendered as a tall bar just like a positive one, so a user could not see where the account crossed into the red.

## What changed

- Bars are now anchored on a zero baseline: they grow up from zero for positive balances and down from zero for negative ones.
- Zero is always kept inside the visible range, so the sign of the balance and any crossing into the red are readable.
- Row fill uses band overlap, so bars stay continuous even when no row lands exactly on zero (the row nearest zero fills across every column and reads as the baseline).
- Extracted the renderer into a module-level function (it never used instance state), which also makes it directly testable.

## Tests

Added coverage for a mixed positive/negative series, an all-negative series, and a positive-only series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)