### PR TITLE
fix: refresh review after category or link change

### DIFF
--- a/budget_forecaster/services/application_service.py
+++ b/budget_forecaster/services/application_service.py
@@ -346,6 +346,14 @@ class ApplicationService:  # pylint: disable=too-many-instance-attributes,too-ma
         """Load the forecast from the database."""
         return self._forecast_service.load_forecast()
 
+    def reload_forecast(self) -> Forecast:
+        """Reload the forecast and drop the cached report.
+
+        Use this after operations change (category, link) so the next report
+        computation reflects the new data instead of returning a stale one.
+        """
+        return self._forecast_service.reload_forecast()
+
     def compute_report(
         self,
         start_date: date | None = None,

--- a/budget_forecaster/tui/modals/operation_detail.py
+++ b/budget_forecaster/tui/modals/operation_detail.py
@@ -234,6 +234,9 @@ class OperationDetailModal(ModalScreen[bool]):
         """Handle category change result."""
         if result is not None:
             self._app_service.categorize_operations((self._operation_id,), result)
+            # A category change moves the operation between report buckets, so
+            # the forecast views need to recompute, not only save.
+            self.post_message(DataRefreshRequested())
             self.post_message(SaveRequested())
             self._modified = True
 

--- a/budget_forecaster/tui/screens/balance.py
+++ b/budget_forecaster/tui/screens/balance.py
@@ -155,7 +155,7 @@ class BalanceWidget(Vertical):
     def refresh_data(self) -> None:
         """Refresh data — invalidate cached report so next tab open recomputes."""
         if self._app_service is not None:
-            self._app_service.load_forecast()
+            self._app_service.reload_forecast()
         self._update_export_button()
 
     def compute_and_display(self) -> None:

--- a/budget_forecaster/tui/screens/review.py
+++ b/budget_forecaster/tui/screens/review.py
@@ -271,7 +271,7 @@ class ReviewWidget(Vertical):
     def refresh_data(self) -> None:
         """Refresh data — invalidate cached report so next tab open recomputes."""
         if self._app_service is not None:
-            self._app_service.load_forecast()
+            self._app_service.reload_forecast()
         self._summaries = []
 
     def compute_and_display(self) -> None:

--- a/tests/services/test_application_service.py
+++ b/tests/services/test_application_service.py
@@ -1143,3 +1143,21 @@ class TestSplitOperations:
         # The method finds the first future iteration without a link
         assert result is not None
         assert result not in {date(2025, 1, 1), date(2025, 2, 1)}
+
+
+class TestReloadForecast:
+    """Tests for forecast reload / report invalidation."""
+
+    def test_reload_forecast_delegates_to_forecast_service(
+        self,
+        app_service: ApplicationService,
+        mock_forecast_service: MagicMock,
+    ) -> None:
+        """reload_forecast drops the cached report via the forecast service."""
+        reloaded = MagicMock()
+        mock_forecast_service.reload_forecast.return_value = reloaded
+
+        result = app_service.reload_forecast()
+
+        assert result is reloaded
+        mock_forecast_service.reload_forecast.assert_called_once_with()

--- a/tests/tui/modals/test_operation_detail.py
+++ b/tests/tui/modals/test_operation_detail.py
@@ -18,7 +18,7 @@ from budget_forecaster.domain.operation.historic_operation import HistoricOperat
 from budget_forecaster.domain.operation.operation_link import OperationLink
 from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.services.application_service import ApplicationService
-from budget_forecaster.tui.messages import SaveRequested
+from budget_forecaster.tui.messages import DataRefreshRequested, SaveRequested
 from budget_forecaster.tui.modals.operation_detail import OperationDetailModal
 
 
@@ -81,6 +81,10 @@ class OperationDetailTestApp(App[None]):
 
     def on_save_requested(self, event: SaveRequested) -> None:
         """Track SaveRequested messages."""
+        self.received_messages.append(event)
+
+    def on_data_refresh_requested(self, event: DataRefreshRequested) -> None:
+        """Track DataRefreshRequested messages."""
         self.received_messages.append(event)
 
 
@@ -368,3 +372,25 @@ class TestOperationDetailLinkButton:
             await pilot.pause()
 
             assert any(isinstance(m, SaveRequested) for m in app.received_messages)
+            assert any(
+                isinstance(m, DataRefreshRequested) for m in app.received_messages
+            )
+
+    @pytest.mark.asyncio
+    async def test_category_change_posts_save_and_refresh_messages(self) -> None:
+        """Changing category posts both SaveRequested and DataRefreshRequested."""
+        service = _make_app_service()
+
+        app = OperationDetailTestApp(service)
+        async with app.run_test() as pilot:
+            app.open_modal()
+            await pilot.pause()
+
+            app.screen._on_category_changed(Category.RENT)
+            await pilot.pause()
+
+            service.categorize_operations.assert_called_once()
+            assert any(isinstance(m, SaveRequested) for m in app.received_messages)
+            assert any(
+                isinstance(m, DataRefreshRequested) for m in app.received_messages
+            )

--- a/tests/tui/test_balance_widget.py
+++ b/tests/tui/test_balance_widget.py
@@ -108,8 +108,8 @@ async def test_compute_and_display_skips_if_report_cached() -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_data_calls_load_forecast() -> None:
-    """refresh_data calls load_forecast to invalidate the cache."""
+async def test_refresh_data_reloads_forecast() -> None:
+    """refresh_data reloads the forecast, dropping the cached report."""
     app_service = _make_app_service(has_report=True)
 
     app = BalanceTestApp(app_service)
@@ -117,7 +117,7 @@ async def test_refresh_data_calls_load_forecast() -> None:
         widget = app.query_one(BalanceWidget)
         widget.refresh_data()
 
-        app_service.load_forecast.assert_called_once()
+        app_service.reload_forecast.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

The budget review tab kept showing stale figures after editing an operation from another tab. Changing a category or a link did not update the review.

Three causes combined:

1. `ReviewWidget.refresh_data` reloaded the forecast but did not drop the cached report, so the tab's early-return on a non-null report re-rendered the old numbers. The balance widget had the same bug.
2. A category change posted only `SaveRequested`, never `DataRefreshRequested`, so it never entered the refresh path.
3. The report cache had no application-level way to be invalidated from the widgets.

## What changed

- Added `ApplicationService.reload_forecast`, which drops the cached report so the next computation reflects the new data.
- `ReviewWidget.refresh_data` and `BalanceWidget.refresh_data` now call it instead of `load_forecast`.
- The operation detail modal now posts `DataRefreshRequested` on a category change, alongside `SaveRequested`.

## Tests

- `reload_forecast` delegates to the forecast service.
- The category change posts both `SaveRequested` and `DataRefreshRequested` (and the unlink test now asserts both, matching its name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)