### PR TITLE
fix: freeze time in date-dependent margin tests

### DIFF
--- a/tests/services/forecast/test_margin.py
+++ b/tests/services/forecast/test_margin.py
@@ -96,6 +96,7 @@ class TestGetAvailableMargin:
         result = service.get_available_margin(date(2026, 3, 1), threshold=0)
         assert result is None
 
+    @freeze_time("2026-03-01")
     @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
     def test_basic_margin_no_threshold(
         self,
@@ -123,6 +124,7 @@ class TestGetAvailableMargin:
         assert result["lowest_balance_date"] == date(2026, 4, 15)
         assert result["threshold"] == 0
 
+    @freeze_time("2026-03-01")
     @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
     def test_margin_with_threshold(
         self,
@@ -146,6 +148,7 @@ class TestGetAvailableMargin:
         assert result["lowest_balance"] == 1500
         assert result["threshold"] == 500
 
+    @freeze_time("2026-03-01")
     @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
     def test_negative_margin_alert(
         self,
@@ -169,6 +172,7 @@ class TestGetAvailableMargin:
         assert result["lowest_balance"] == 300
         assert result["lowest_balance_date"] == date(2026, 4, 1)
 
+    @freeze_time("2026-03-01")
     @patch("budget_forecaster.services.forecast.forecast_service.AccountAnalyzer")
     def test_margin_from_future_month(
         self,


### PR DESCRIPTION
## Context

Four `get_available_margin` tests in `test_margin.py` request past months (March/April 2026) but do not freeze the clock. Once #282 started excluding past dates from the available margin, these tests return `None` on any real date after those months, so the test suite fails on `main` (and on every open PR branched from it).

## What changed

Added `@freeze_time("2026-03-01")` to the four affected tests, matching the pattern already used by `test_excludes_past_dates_from_lowest_balance`. No production code change — the #282 behavior is correct; only the tests were time-fragile.

## Note

This is a pre-existing failure on `main`, unrelated to the current batch of bug-fix PRs. Merging it first unblocks their CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)