### PR TITLE
chore: ignore venv and local data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ coverage.xml
 *.xlsx
 .claude/
 CLAUDE.md
+budget-forecaster-venv/
+config.yaml
+.mcp.json
+examples/data/processed/
+examples/data/swile-export-2026-03-09.zip


### PR DESCRIPTION
## Context

Adds local-only artifacts to `.gitignore` so they stop showing up as untracked: the project virtualenv, local config, and local example data.

This commit already existed locally on `main` but was never published (direct pushes to `main` are blocked by policy), so it goes through a PR.

## What changed

Five entries added to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)