### PR TITLE
feat: Enable Banking sync service + CLI command (#292)

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -96,6 +96,7 @@ réel
 salaire
 solde
 str
+subcommand
 submodules
 supermarche
 supermarché
@@ -116,6 +117,7 @@ unlinking
 unmapped
 upsert
 upserting
+upserts
 whitespace
 widget's
 xdg

--- a/.custom.dic
+++ b/.custom.dic
@@ -109,6 +109,7 @@ tui
 ui
 uids
 uncategorized
+unconfigured
 unforecasted
 unicode
 unlink

--- a/budget_forecaster/default_config.yaml
+++ b/budget_forecaster/default_config.yaml
@@ -13,6 +13,12 @@ backup:
   enabled: true
   max_backups: 5
   directory: ~/.local/share/budget-forecaster/backups/
+# Optional - Enable Banking API source (used by the `sync` command)
+# enable_banking:
+#   application_id: "your-application-id"
+#   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
+#   redirect_url: "https://your-redirect-url"
+#   account_uid: "the-account-uid-from-a-prior-consent"
 # logging:  # Override default logging (~/.local/share/budget-forecaster/budget-forecaster.log)
 #   version: 1
 #   disable_existing_loggers: false

--- a/budget_forecaster/infrastructure/bootstrap.py
+++ b/budget_forecaster/infrastructure/bootstrap.py
@@ -1,0 +1,41 @@
+"""Shared database bootstrap for the TUI and CLI entry points.
+
+Backs up the database, runs migrations, and seeds the aggregated account name
+on an empty database. Both entry points open the repository the same way.
+"""
+
+import logging
+
+from budget_forecaster.exceptions import BackupError
+from budget_forecaster.infrastructure.backup import BackupService
+from budget_forecaster.infrastructure.config import Config
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def open_repository(config: Config) -> SqliteRepository:
+    """Back up, migrate and return the repository ready to use."""
+    if config.backup.enabled:
+        backup_service = BackupService(
+            database_path=config.database_path,
+            backup_directory=config.backup.directory,
+            max_backups=config.backup.max_backups,
+        )
+        try:
+            backup_path = backup_service.create_backup()
+            logger.info("Database backup created: %s", backup_path)
+        except BackupError:
+            logger.exception("Backup failed")
+        backup_service.rotate_backups()
+
+    repository = SqliteRepository(config.database_path)
+    repository.initialize()
+
+    if repository.get_aggregated_account_name() is None:
+        logger.info("Empty database detected, initializing aggregated account")
+        repository.set_aggregated_account_name(config.account.name)
+
+    return repository

--- a/budget_forecaster/infrastructure/config.py
+++ b/budget_forecaster/infrastructure/config.py
@@ -40,11 +40,13 @@ class BackupConfig(NamedTuple):
 
 
 class EnableBankingConfig(NamedTuple):
-    """Credentials for the Enable Banking API source."""
+    """Credentials and target account for the Enable Banking API source."""
 
     application_id: str
     private_key_path: Path
     redirect_url: str
+    account_uid: str
+    """Enable Banking account identifier to sync (from a prior consent)."""
 
 
 class Config:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -107,6 +109,7 @@ class Config:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
                     application_id=eb_cfg["application_id"],
                     private_key_path=Path(eb_cfg["private_key_path"]).expanduser(),
                     redirect_url=eb_cfg["redirect_url"],
+                    account_uid=eb_cfg["account_uid"],
                 )
 
     def setup_logging(self) -> None:

--- a/budget_forecaster/infrastructure/persistence/persistent_account.py
+++ b/budget_forecaster/infrastructure/persistence/persistent_account.py
@@ -8,6 +8,9 @@ from budget_forecaster.exceptions import AccountNotLoadedError
 from budget_forecaster.infrastructure.persistence.repository_interface import (
     RepositoryInterface,
 )
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
 
 
 class PersistentAccount:
@@ -43,6 +46,14 @@ class PersistentAccount:
 
         accounts = self._repository.get_all_accounts()
         return AggregatedAccount(aggregated_name, accounts)
+
+    def next_operation_factory(self) -> HistoricOperationFactory:
+        """Create an operation factory seeded past the highest existing id.
+
+        Keeps operation ids unique whatever the source (file import, API sync).
+        """
+        last_id = max((op.unique_id for op in self.account.operations), default=0)
+        return HistoricOperationFactory(last_id)
 
     def save(self) -> None:
         """Save the accounts to the repository."""

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -1,10 +1,38 @@
 """Main module for the Budget Forecaster application."""
 
 import argparse
+import logging
 import sys
 from pathlib import Path
 
+from budget_forecaster.exceptions import BackupError
+from budget_forecaster.infrastructure.backup import BackupService
+from budget_forecaster.infrastructure.bank_sources.enable_banking.client import (
+    EnableBankingClient,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.source import (
+    EnableBankingSource,
+)
+from budget_forecaster.infrastructure.config import Config
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+from budget_forecaster.services.bank_sync_service import BankSyncService
+from budget_forecaster.services.forecast.forecast_service import ForecastService
+from budget_forecaster.services.operation.operation_link_service import (
+    OperationLinkService,
+)
+from budget_forecaster.services.use_cases import MatcherCache, SyncUseCase
 from budget_forecaster.tui.app import run_app
+
+logger = logging.getLogger(__name__)
+
+# Local account name for the Enable Banking source. Must match the BNP file
+# adapter so xls and API operations reconcile into the same sub-account.
+_BNP_ACCOUNT_NAME = "bnp"
 
 
 def _create_default_config(config_path: Path) -> None:
@@ -20,11 +48,74 @@ def _create_default_config(config_path: Path) -> None:
     config_path.write_text(template_content, encoding="utf-8")
 
 
+def _open_repository(config: Config) -> SqliteRepository:
+    """Open the database, backing it up first and bootstrapping if empty."""
+    if config.backup.enabled:
+        backup_service = BackupService(
+            database_path=config.database_path,
+            backup_directory=config.backup.directory,
+            max_backups=config.backup.max_backups,
+        )
+        try:
+            backup_service.create_backup()
+        except BackupError:
+            logger.exception("Backup failed")
+        backup_service.rotate_backups()
+
+    repository = SqliteRepository(config.database_path)
+    repository.initialize()
+    if repository.get_aggregated_account_name() is None:
+        repository.set_aggregated_account_name(config.account.name)
+    return repository
+
+
+def _run_sync(config_path: Path) -> None:
+    """Sync the configured Enable Banking account into the local database."""
+    config = Config()
+    config.parse(config_path)
+    config.setup_logging()
+
+    if (enable_banking := config.enable_banking) is None:
+        print(
+            "Enable Banking is not configured. "
+            "Add an 'enable_banking' section to your config file.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    repository = _open_repository(config)
+    persistent_account = PersistentAccount(repository)
+    try:
+        client = EnableBankingClient(
+            enable_banking.application_id,
+            enable_banking.private_key_path,
+            enable_banking.redirect_url,
+        )
+        source = EnableBankingSource(client, name=_BNP_ACCOUNT_NAME)
+        sync_use_case = SyncUseCase(
+            BankSyncService(persistent_account, source),
+            persistent_account,
+            OperationLinkService(repository),
+            MatcherCache(ForecastService(persistent_account, repository)),
+        )
+        stats = sync_use_case.sync(enable_banking.account_uid)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Sync failed")
+        print("Sync failed. See the log for details.", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        repository.close()
+
+    account = persistent_account.account
+    print(
+        f"Synced {source.name}: {stats.new_operations} new, "
+        f"{stats.duplicates_skipped} duplicates skipped. "
+        f"Balance: {account.balance:.2f} {account.currency}"
+    )
+
+
 def main() -> None:
-    """
-    Entry point for the Budget Forecaster application.
-    Launches the interactive TUI interface.
-    """
+    """Entry point: launch the TUI, or run a subcommand such as sync."""
     default_config_path = Path("~/.config/budget-forecaster/config.yaml").expanduser()
 
     parser = argparse.ArgumentParser(
@@ -37,6 +128,8 @@ def main() -> None:
         type=Path,
         default=default_config_path,
     )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("sync", help="Sync a linked bank account via Enable Banking")
     args = parser.parse_args()
 
     config_path = args.config.expanduser()
@@ -47,7 +140,10 @@ def main() -> None:
         print("Please edit it to customize your settings, then run again.")
         sys.exit(0)
 
-    run_app(config_path)
+    if args.command == "sync":
+        _run_sync(config_path)
+    else:
+        run_app(config_path)
 
 
 if __name__ == "__main__":

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -5,20 +5,16 @@ import logging
 import sys
 from pathlib import Path
 
-from budget_forecaster.exceptions import BackupError
-from budget_forecaster.infrastructure.backup import BackupService
 from budget_forecaster.infrastructure.bank_sources.enable_banking.client import (
     EnableBankingClient,
 )
 from budget_forecaster.infrastructure.bank_sources.enable_banking.source import (
     EnableBankingSource,
 )
+from budget_forecaster.infrastructure.bootstrap import open_repository
 from budget_forecaster.infrastructure.config import Config
 from budget_forecaster.infrastructure.persistence.persistent_account import (
     PersistentAccount,
-)
-from budget_forecaster.infrastructure.persistence.sqlite_repository import (
-    SqliteRepository,
 )
 from budget_forecaster.services.bank_sync_service import BankSyncService
 from budget_forecaster.services.forecast.forecast_service import ForecastService
@@ -48,27 +44,6 @@ def _create_default_config(config_path: Path) -> None:
     config_path.write_text(template_content, encoding="utf-8")
 
 
-def _open_repository(config: Config) -> SqliteRepository:
-    """Open the database, backing it up first and bootstrapping if empty."""
-    if config.backup.enabled:
-        backup_service = BackupService(
-            database_path=config.database_path,
-            backup_directory=config.backup.directory,
-            max_backups=config.backup.max_backups,
-        )
-        try:
-            backup_service.create_backup()
-        except BackupError:
-            logger.exception("Backup failed")
-        backup_service.rotate_backups()
-
-    repository = SqliteRepository(config.database_path)
-    repository.initialize()
-    if repository.get_aggregated_account_name() is None:
-        repository.set_aggregated_account_name(config.account.name)
-    return repository
-
-
 def _run_sync(config_path: Path) -> None:
     """Sync the configured Enable Banking account into the local database."""
     config = Config()
@@ -83,9 +58,10 @@ def _run_sync(config_path: Path) -> None:
         )
         sys.exit(1)
 
-    repository = _open_repository(config)
-    persistent_account = PersistentAccount(repository)
+    repository = None
     try:
+        repository = open_repository(config)
+        persistent_account = PersistentAccount(repository)
         client = EnableBankingClient(
             enable_banking.application_id,
             enable_banking.private_key_path,
@@ -99,19 +75,19 @@ def _run_sync(config_path: Path) -> None:
             MatcherCache(ForecastService(persistent_account, repository)),
         )
         stats = sync_use_case.sync(enable_banking.account_uid)
+        account = persistent_account.account
+        print(
+            f"Synced {source.name}: {stats.new_operations} new, "
+            f"{stats.duplicates_skipped} duplicates skipped. "
+            f"Balance: {account.balance:.2f} {account.currency}"
+        )
     except Exception:  # pylint: disable=broad-except
         logger.exception("Sync failed")
         print("Sync failed. See the log for details.", file=sys.stderr)
         sys.exit(1)
     finally:
-        repository.close()
-
-    account = persistent_account.account
-    print(
-        f"Synced {source.name}: {stats.new_operations} new, "
-        f"{stats.duplicates_skipped} duplicates skipped. "
-        f"Balance: {account.balance:.2f} {account.currency}"
-    )
+        if repository is not None:
+            repository.close()
 
 
 def main() -> None:

--- a/budget_forecaster/services/bank_sync_service.py
+++ b/budget_forecaster/services/bank_sync_service.py
@@ -1,0 +1,66 @@
+"""Service for syncing a bank account from an API source.
+
+Fetches operations and balance from an API bank source and merges them into
+the local account through the same path as file import, so the existing
+source_ref dedup makes re-runs idempotent and reconciles overlapping file/API
+operations.
+"""
+
+import logging
+from datetime import date
+
+from budget_forecaster.core.types import ImportStats
+from budget_forecaster.domain.account.account import AccountParameters
+from budget_forecaster.infrastructure.bank_sources.bank_source import ApiBankSource
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BankSyncService:  # pylint: disable=too-few-public-methods
+    """Sync a single account from a remote API source into the local DB."""
+
+    def __init__(
+        self,
+        persistent_account: PersistentAccount,
+        api_source: ApiBankSource,
+    ) -> None:
+        self._persistent_account = persistent_account
+        self._api_source = api_source
+
+    def sync(self, account_uid: str, date_from: date | None = None) -> ImportStats:
+        """Fetch the account from the API source and merge it locally.
+
+        Args:
+            account_uid: The source-side account identifier to fetch.
+            date_from: Optional lower bound on the fetched transactions. When
+                omitted, the full available history is fetched; dedup keeps the
+                merge idempotent either way.
+
+        Returns:
+            ImportStats with the number of new and duplicate operations.
+        """
+        operation_factory = self._persistent_account.next_operation_factory()
+        self._api_source.fetch(account_uid, operation_factory, date_from)
+
+        account_params = AccountParameters(
+            name=self._api_source.name,
+            balance=self._api_source.balance,
+            currency="EUR",
+            balance_date=self._api_source.export_date or date.today(),
+            operations=self._api_source.operations,
+        )
+
+        stats = self._persistent_account.upsert_account(account_params)
+        self._persistent_account.save()
+        self._persistent_account.reload()
+
+        logger.info(
+            "Synced %s: %d new, %d duplicates skipped",
+            self._api_source.name,
+            stats.new_operations,
+            stats.duplicates_skipped,
+        )
+        return stats

--- a/budget_forecaster/services/bank_sync_service.py
+++ b/budget_forecaster/services/bank_sync_service.py
@@ -45,6 +45,12 @@ class BankSyncService:  # pylint: disable=too-few-public-methods
         operation_factory = self._persistent_account.next_operation_factory()
         self._api_source.fetch(account_uid, operation_factory, date_from)
 
+        if self._api_source.balance is None:
+            logger.warning(
+                "No closing booked (CLBD) balance returned for %s",
+                self._api_source.name,
+            )
+
         account_params = AccountParameters(
             name=self._api_source.name,
             balance=self._api_source.balance,

--- a/budget_forecaster/services/import_service.py
+++ b/budget_forecaster/services/import_service.py
@@ -19,9 +19,6 @@ from budget_forecaster.infrastructure.bank_sources.file_export_adapter_factory i
 from budget_forecaster.infrastructure.persistence.persistent_account import (
     PersistentAccount,
 )
-from budget_forecaster.services.operation.historic_operation_factory import (
-    HistoricOperationFactory,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -114,16 +111,6 @@ class ImportService:
 
         return True
 
-    def _get_last_operation_id(self) -> int:
-        """Get the last operation id."""
-        if not (operations := self._persistent_account.account.operations):
-            return 0
-        return max(op.unique_id for op in operations)
-
-    def _create_operation_factory(self) -> HistoricOperationFactory:
-        """Create an operation factory with the next available ID."""
-        return HistoricOperationFactory(self._get_last_operation_id())
-
     def get_supported_exports_in_inbox(self) -> list[Path]:
         """Get all supported bank exports in the inbox folder.
 
@@ -173,7 +160,7 @@ class ImportService:
         Returns:
             ImportResult with the outcome and import statistics.
         """
-        operation_factory = self._create_operation_factory()
+        operation_factory = self._persistent_account.next_operation_factory()
 
         try:
             adapter = self._file_export_adapter_factory.create_adapter(path)

--- a/budget_forecaster/services/use_cases/__init__.py
+++ b/budget_forecaster/services/use_cases/__init__.py
@@ -14,6 +14,7 @@ from budget_forecaster.services.use_cases.manage_targets_use_case import (
     ManageTargetsUseCase,
 )
 from budget_forecaster.services.use_cases.matcher_cache import MatcherCache
+from budget_forecaster.services.use_cases.sync_use_case import SyncUseCase
 
 __all__ = [
     "CategorizeUseCase",
@@ -22,4 +23,5 @@ __all__ = [
     "ManageLinksUseCase",
     "ManageTargetsUseCase",
     "MatcherCache",
+    "SyncUseCase",
 ]

--- a/budget_forecaster/services/use_cases/sync_use_case.py
+++ b/budget_forecaster/services/use_cases/sync_use_case.py
@@ -1,0 +1,45 @@
+"""Use case for syncing a bank account from an API source."""
+
+import logging
+from datetime import date
+
+from budget_forecaster.core.types import ImportStats
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+from budget_forecaster.services.bank_sync_service import BankSyncService
+from budget_forecaster.services.operation.operation_link_service import (
+    OperationLinkService,
+)
+from budget_forecaster.services.use_cases.matcher_cache import MatcherCache
+
+logger = logging.getLogger(__name__)
+
+
+class SyncUseCase:  # pylint: disable=too-few-public-methods
+    """Sync an account from an API source and create heuristic links."""
+
+    def __init__(
+        self,
+        sync_service: BankSyncService,
+        persistent_account: PersistentAccount,
+        operation_link_service: OperationLinkService,
+        matcher_cache: MatcherCache,
+    ) -> None:
+        self._sync_service = sync_service
+        self._persistent_account = persistent_account
+        self._operation_link_service = operation_link_service
+        self._matcher_cache = matcher_cache
+
+    def sync(self, account_uid: str, date_from: date | None = None) -> ImportStats:
+        """Sync the account, then link the resulting operations to targets."""
+        stats = self._sync_service.sync(account_uid, date_from)
+
+        operations = self._persistent_account.account.operations
+        if matchers := self._matcher_cache.get_matchers():
+            created_links = self._operation_link_service.create_heuristic_links(
+                operations, matchers
+            )
+            logger.info("Created %d heuristic links after sync", len(created_links))
+
+        return stats

--- a/budget_forecaster/tui/app.py
+++ b/budget_forecaster/tui/app.py
@@ -24,17 +24,13 @@ from budget_forecaster.domain.operation.historic_operation import HistoricOperat
 from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.exceptions import (
     AccountNotLoadedError,
-    BackupError,
     BudgetForecasterError,
 )
 from budget_forecaster.i18n import _, setup_i18n
-from budget_forecaster.infrastructure.backup import BackupService
+from budget_forecaster.infrastructure.bootstrap import open_repository
 from budget_forecaster.infrastructure.config import Config
 from budget_forecaster.infrastructure.persistence.persistent_account import (
     PersistentAccount,
-)
-from budget_forecaster.infrastructure.persistence.sqlite_repository import (
-    SqliteRepository,
 )
 from budget_forecaster.services.application_service import ApplicationService
 from budget_forecaster.services.forecast.forecast_service import ForecastService
@@ -161,28 +157,7 @@ class BudgetApp(
         self._config.setup_logging()
         logger.info("Starting Budget Forecaster TUI")
 
-        # Create backup before any database access
-        if self._config.backup.enabled:
-            backup_service = BackupService(
-                database_path=self._config.database_path,
-                backup_directory=self._config.backup.directory,
-                max_backups=self._config.backup.max_backups,
-            )
-            try:
-                backup_path = backup_service.create_backup()
-                logger.info("Database backup created: %s", backup_path)
-            except BackupError:
-                logger.exception("Backup failed")
-            backup_service.rotate_backups()
-
-        repository = SqliteRepository(self._config.database_path)
-        repository.initialize()
-
-        # Bootstrap empty database with aggregated account name from config
-        if repository.get_aggregated_account_name() is None:
-            logger.info("Empty database detected, initializing aggregated account")
-            repository.set_aggregated_account_name(self._config.account.name)
-
+        repository = open_repository(self._config)
         self._persistent_account = PersistentAccount(repository)
 
         # Create individual services

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -70,7 +70,8 @@ categorizes transactions, and generates balance forecasts.
 
 The **Presentation** layer provides user interfaces: a Terminal UI for interactive use
 and a CLI for scripted operations. Both delegate to **Services**, which orchestrate
-business logic.
+business logic. The CLI launches the TUI by default, or runs the `sync` command to pull
+transactions and balance from an API bank source into the local database.
 
 The **Services** layer coordinates domain objects and implements use cases.
 `ApplicationService` is a thin facade that delegates orchestration to focused use cases:
@@ -82,6 +83,10 @@ The **Services** layer coordinates domain objects and implements use cases.
 - `ManageLinksUseCase`: Manual link creation
 - `ComputeForecastUseCase`: Forecast report computation
 - `MatcherCache`: Shared lazy-loaded cache of operation matchers
+
+The `sync` CLI command uses `SyncUseCase` directly (outside `ApplicationService`): it
+fetches operations and balance from an API bank source, merges them through the same
+deduplicating path as file import, then creates heuristic links.
 
 Lower-level services handle specific concerns:
 
@@ -100,7 +105,7 @@ The **Core** layer provides foundational types (Amount, DateRange, Category) wit
 external dependencies.
 
 The **Infrastructure** layer handles external concerns: SQLite persistence, bank file
-parsing (BNP, Swile), configuration, and rendering.
+parsing (BNP, Swile), the Enable Banking API source, configuration, and rendering.
 
 ## Documentation Index
 

--- a/docs/dev/persistence.md
+++ b/docs/dev/persistence.md
@@ -70,6 +70,7 @@ erDiagram
         timestamp date
         real amount
         text currency
+        text source_ref "nullable dedup key"
     }
 
     planned_operations {
@@ -113,6 +114,31 @@ erDiagram
     planned_operations ||--o{ operation_links : "targeted by"
     budgets ||--o{ operation_links : "targeted by"
 ```
+
+## Schema Migrations
+
+The schema is versioned. On open, `initialize()` applies each pending migration in order
+up to the current version, so an older database is upgraded transparently. Migrations
+are ordered steps held in a single registry.
+
+Version 8 added the `source_ref` column on operations, the natural deduplication key.
+
+## Deduplication
+
+An operation carries a `source_ref` when its source provides a stable reference:
+
+- API operations use the bank's entry reference.
+- File imports (BNP, Swile) leave it NULL; a content reference (a hash of date, amount
+  and description) is derived on the fly instead.
+
+An incoming operation is a duplicate when either:
+
+- it has a reference and that reference is already stored for the account, or
+- it has no reference and its content reference matches a stored reference-less
+  operation.
+
+Two identical same-day API operations are both kept (distinct references); the content
+hash only collapses duplicates between file imports.
 
 ## Service Layer
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -42,6 +42,13 @@ backup:
 # Optional - Language for the UI and exports (default: en)
 # language: fr
 
+# Optional - Enable Banking API source (used by the `sync` command)
+# enable_banking:
+#   application_id: "your-application-id"
+#   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
+#   redirect_url: "https://your-redirect-url"
+#   account_uid: "the-account-uid-from-a-prior-consent"
+
 # Optional - Python dictConfig format for logging
 # logging:
 #   version: 1
@@ -69,6 +76,24 @@ backup:
 | `backup.directory`       | no       | _(database directory)_ | Where to store backup files                |
 | `language`               | no       | `en`                   | UI and export language (`en` or `fr`)      |
 | `logging`                | no       | basic INFO logging     | Python dictConfig format for logging setup |
+| `enable_banking`         | no       | _(disabled)_           | Enable Banking credentials for `sync`      |
+
+## Syncing bank data (Enable Banking)
+
+The `sync` command imports transactions and the account balance directly from the bank
+through Enable Banking, as an alternative to loading exported files:
+
+```bash
+budget-forecaster sync
+```
+
+It reads the `enable_banking` section from the config, fetches the account identified by
+`account_uid`, and merges the operations into the local database. Re-running the command
+is safe: already-imported operations are skipped, and operations that overlap with a
+manual file import are reconciled rather than duplicated.
+
+Obtaining the `application_id`, private key, `redirect_url`, and `account_uid` requires
+a one-time Enable Banking setup, documented separately.
 
 ## Inbox Auto-Detection
 

--- a/tests/fixtures/configs/full_config.yaml
+++ b/tests/fixtures/configs/full_config.yaml
@@ -27,3 +27,4 @@ enable_banking:
   application_id: app-1234
   private_key_path: ~/.config/budget-forecaster/eb_private_key.pem
   redirect_url: https://localhost:8080/callback
+  account_uid: acc-uid-1234

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -103,6 +103,7 @@ class TestConfigParseYaml:
                 "~/.config/budget-forecaster/eb_private_key.pem"
             ).expanduser(),
             redirect_url="https://localhost:8080/callback",
+            account_uid="acc-uid-1234",
         )
 
     def test_parse_backup_partial_config(self) -> None:

--- a/tests/services/test_bank_sync_service.py
+++ b/tests/services/test_bank_sync_service.py
@@ -1,0 +1,73 @@
+"""Unit tests for BankSyncService."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.core.types import Category, ImportStats
+from budget_forecaster.services.bank_sync_service import BankSyncService
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+
+def _operation(factory: HistoricOperationFactory, description: str, amount: float):
+    return factory.create_operation(
+        description=description,
+        amount=Amount(amount, "EUR"),
+        category=Category.UNCATEGORIZED,
+        operation_date=date(2026, 1, 10),
+        source_ref=description,
+    )
+
+
+def test_sync_fetches_source_and_merges_into_account() -> None:
+    """sync fetches the source and upserts its operations and balance."""
+    factory = HistoricOperationFactory(0)
+    operations = (
+        _operation(factory, "COFFEE", -3.5),
+        _operation(factory, "SALARY", 2000.0),
+    )
+
+    source = MagicMock()
+    source.name = "bnp"
+    source.balance = 1500.0
+    source.export_date = date(2026, 1, 15)
+    source.operations = operations
+
+    persistent_account = MagicMock()
+    persistent_account.next_operation_factory.return_value = factory
+    stats = ImportStats(total_in_file=2, new_operations=2, duplicates_skipped=0)
+    persistent_account.upsert_account.return_value = stats
+
+    service = BankSyncService(persistent_account, source)
+    result = service.sync("acc-1", date_from=date(2026, 1, 1))
+
+    source.fetch.assert_called_once_with("acc-1", factory, date(2026, 1, 1))
+    account_params = persistent_account.upsert_account.call_args.args[0]
+    assert account_params.name == "bnp"
+    assert account_params.balance == 1500.0
+    assert account_params.currency == "EUR"
+    assert account_params.balance_date == date(2026, 1, 15)
+    assert account_params.operations == operations
+    persistent_account.save.assert_called_once()
+    persistent_account.reload.assert_called_once()
+    assert result == stats
+
+
+def test_sync_falls_back_to_today_when_source_has_no_date() -> None:
+    """A source without an export date dates the account at today."""
+    source = MagicMock()
+    source.name = "bnp"
+    source.balance = None
+    source.export_date = None
+    source.operations = ()
+
+    persistent_account = MagicMock()
+    persistent_account.next_operation_factory.return_value = HistoricOperationFactory(0)
+    persistent_account.upsert_account.return_value = ImportStats(0, 0, 0)
+
+    BankSyncService(persistent_account, source).sync("acc-1")
+
+    account_params = persistent_account.upsert_account.call_args.args[0]
+    assert account_params.balance_date == date.today()

--- a/tests/services/use_cases/test_sync_use_case_integration.py
+++ b/tests/services/use_cases/test_sync_use_case_integration.py
@@ -1,0 +1,174 @@
+"""Integration tests for SyncUseCase with real persistence.
+
+The Enable Banking HTTP client is the only mocked boundary; everything from the
+source mapping down to the SQLite merge runs for real.
+"""
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.core.types import Category
+from budget_forecaster.domain.account.account import Account
+from budget_forecaster.infrastructure.bank_sources.enable_banking.source import (
+    EnableBankingSource,
+)
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+from budget_forecaster.services.bank_sync_service import BankSyncService
+from budget_forecaster.services.forecast.forecast_service import ForecastService
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+from budget_forecaster.services.operation.operation_link_service import (
+    OperationLinkService,
+)
+from budget_forecaster.services.use_cases.matcher_cache import MatcherCache
+from budget_forecaster.services.use_cases.sync_use_case import SyncUseCase
+
+ACCOUNT_NAME = "bnp"
+
+
+def _transaction(
+    entry_reference: str,
+    description: str,
+    amount: str,
+    indicator: str,
+    booking_date: str,
+) -> dict[str, Any]:
+    """Build a booked Enable Banking transaction payload."""
+    return {
+        "status": "BOOK",
+        "entry_reference": entry_reference,
+        "booking_date": booking_date,
+        "credit_debit_indicator": indicator,
+        "transaction_amount": {"currency": "EUR", "amount": amount},
+        "remittance_information": [description],
+    }
+
+
+API_TRANSACTIONS = (
+    _transaction("ref-coffee", "COFFEE", "3.50", "DBIT", "2026-01-10"),
+    _transaction("ref-salary", "SALARY", "2000.00", "CRDT", "2026-01-05"),
+    _transaction("ref-rent", "RENT", "800.00", "DBIT", "2026-01-02"),
+)
+API_BALANCES = ({"balance_type": "CLBD", "balance_amount": {"amount": "1500.00"}},)
+
+
+@pytest.fixture(name="repository")
+def repository_fixture(tmp_path: Path) -> SqliteRepository:
+    """Create a real SQLite repository seeded with an aggregated name."""
+    repository = SqliteRepository(tmp_path / "test.db")
+    repository.initialize()
+    repository.set_aggregated_account_name("Test")
+    return repository
+
+
+def _seed_account(
+    repository: SqliteRepository,
+    operations: tuple = (),
+    balance: float = 0.0,
+    balance_date: date = date(2025, 1, 1),
+) -> None:
+    repository.upsert_account(
+        Account(
+            name=ACCOUNT_NAME,
+            balance=balance,
+            currency="EUR",
+            balance_date=balance_date,
+            operations=operations,
+        )
+    )
+
+
+def _build_use_case(
+    repository: SqliteRepository,
+    persistent_account: PersistentAccount,
+) -> tuple[SyncUseCase, MagicMock]:
+    """Wire a SyncUseCase over a mocked Enable Banking client."""
+    client = MagicMock()
+    client.get_transactions.return_value = API_TRANSACTIONS
+    client.get_balances.return_value = API_BALANCES
+    source = EnableBankingSource(client, name=ACCOUNT_NAME)
+    use_case = SyncUseCase(
+        BankSyncService(persistent_account, source),
+        persistent_account,
+        OperationLinkService(repository),
+        MatcherCache(ForecastService(persistent_account, repository)),
+    )
+    return use_case, client
+
+
+class TestSyncIntegration:
+    """Full sync, re-sync idempotency, and xls reconciliation."""
+
+    def test_creates_operations_and_updates_balance(
+        self, repository: SqliteRepository
+    ) -> None:
+        """A first sync imports the API operations and the CLBD balance."""
+        _seed_account(repository)
+        persistent_account = PersistentAccount(repository)
+        use_case, _ = _build_use_case(repository, persistent_account)
+
+        stats = use_case.sync("acc-1")
+
+        assert stats.new_operations == 3
+        assert stats.duplicates_skipped == 0
+        account = PersistentAccount(repository).account
+        assert len(account.operations) == 3
+        assert account.balance == 1500.0
+        descriptions = {op.description for op in account.operations}
+        assert descriptions == {"COFFEE", "SALARY", "RENT"}
+
+    def test_second_sync_adds_no_duplicates(self, repository: SqliteRepository) -> None:
+        """Re-running the sync is idempotent: no new operations."""
+        _seed_account(repository)
+        persistent_account = PersistentAccount(repository)
+        use_case, _ = _build_use_case(repository, persistent_account)
+
+        use_case.sync("acc-1")
+        second = use_case.sync("acc-1")
+
+        assert second.new_operations == 0
+        assert second.duplicates_skipped == 3
+        assert len(PersistentAccount(repository).account.operations) == 3
+
+    def test_overlapping_file_operation_is_reconciled(
+        self, repository: SqliteRepository
+    ) -> None:
+        """An operation already imported from an xls file is not duplicated."""
+        factory = HistoricOperationFactory(0)
+        # xls op with no source_ref matching the COFFEE API transaction by content
+        xls_coffee = factory.create_operation(
+            description="COFFEE",
+            amount=Amount(-3.5, "EUR"),
+            category=Category.UNCATEGORIZED,
+            operation_date=date(2026, 1, 10),
+            source_ref=None,
+        )
+        _seed_account(
+            repository,
+            operations=(xls_coffee,),
+            balance=1000.0,
+            balance_date=date(2026, 1, 5),
+        )
+        persistent_account = PersistentAccount(repository)
+        use_case, _ = _build_use_case(repository, persistent_account)
+
+        stats = use_case.sync("acc-1")
+
+        # COFFEE reconciled by content; only SALARY and RENT are new.
+        assert stats.new_operations == 2
+        assert stats.duplicates_skipped == 1
+        account = PersistentAccount(repository).account
+        assert len(account.operations) == 3
+        coffee_ops = [op for op in account.operations if op.description == "COFFEE"]
+        assert len(coffee_ops) == 1

--- a/tests/services/use_cases/test_sync_use_case_integration.py
+++ b/tests/services/use_cases/test_sync_use_case_integration.py
@@ -10,10 +10,13 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from budget_forecaster.core.amount import Amount
+from budget_forecaster.core.date_range import RecurringDay
 from budget_forecaster.core.types import Category
 from budget_forecaster.domain.account.account import Account
+from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.infrastructure.bank_sources.enable_banking.source import (
     EnableBankingSource,
 )
@@ -172,3 +175,25 @@ class TestSyncIntegration:
         assert len(account.operations) == 3
         coffee_ops = [op for op in account.operations if op.description == "COFFEE"]
         assert len(coffee_ops) == 1
+
+    def test_sync_creates_heuristic_links(self, repository: SqliteRepository) -> None:
+        """A synced operation matching a planned operation gets linked."""
+        # RENT (-800 on 2026-01-02) matches this monthly planned operation.
+        repository.upsert_planned_operation(
+            PlannedOperation(
+                record_id=None,
+                description="Rent",
+                amount=Amount(-800.0),
+                category=Category.UNCATEGORIZED,
+                date_range=RecurringDay(date(2026, 1, 1), relativedelta(months=1)),
+            )
+        )
+        _seed_account(repository)
+        persistent_account = PersistentAccount(repository)
+        use_case, _ = _build_use_case(repository, persistent_account)
+
+        use_case.sync("acc-1")
+
+        links = repository.get_all_links()
+        assert len(links) > 0
+        assert all(not link.is_manual for link in links)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+"""Tests for the CLI entry point."""
+
+from pathlib import Path
+
+import pytest
+
+from budget_forecaster import main
+
+
+def test_sync_without_enable_banking_exits(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync command exits with an error when Enable Banking is unconfigured."""
+    monkeypatch.setattr(main.Config, "setup_logging", lambda self: None)
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"database_path: {tmp_path / 'x.db'}\n"
+        'account_name: "Test"\n'
+        "account_currency: EUR\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "sys.argv", ["budget-forecaster", "-c", str(config_file), "sync"]
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.main()
+
+    assert exc_info.value.code == 1
+    assert "Enable Banking is not configured" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Wires the Enable Banking API source (#290) and the `source_ref` dedup merge (#291) into a usable sync.

- `BankSyncService` fetches transactions + the `CLBD` balance from the API source and merges them through the **same path as file import** (`PersistentAccount.upsert_account`). The existing two-level dedup makes re-runs idempotent and reconciles operations that overlap a manual xls import.
- `SyncUseCase` adds heuristic links after the sync, mirroring the file-import flow so synced operations show up linked in the review.
- A new `sync` CLI subcommand runs it headlessly. `main.py` now uses argparse subcommands; with no subcommand the TUI launches exactly as before.
- The synced account uses name `bnp` (matching the BNP file adapter) so xls and API operations land in the same sub-account and reconcile.

Per the epic breakdown, the `account_uid` is read from config (`enable_banking.account_uid`). In-app enrollment, consent renewal, and secure token storage remain separate epic items.

## Scope decisions

- **Full fetch each run** (`date_from=None`) — dedup keeps it idempotent; incremental-since-last-date is a later optimization.
- **CLI output is plain English** (no i18n), consistent with the existing `main.py` prints; the TUI stays the translated surface.
- A short `sync` note was added to `docs/user/configuration.md`; the full manual EB setup guide is the separate docs item.

## Test plan

- `tests/services/test_bank_sync_service.py` — unit: source fetched, `AccountParameters` built correctly, save/reload, today fallback.
- `tests/services/use_cases/test_sync_use_case_integration.py` — integration (real SQLite, mocked HTTP client only): full sync + balance, re-sync idempotency, xls/API reconciliation.
- Full suite: 923 passed.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)