### PR TITLE
feat: Enable Banking consent backend

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -6,8 +6,10 @@ ajusté
 al
 alimentaires
 alimentation
+api's
 args
 au
+backend
 backfill
 backfills
 bnp
@@ -30,6 +32,7 @@ dataclass
 dataframe
 daterange
 datetime
+datetimes
 dedup
 deduping
 deduplicates
@@ -106,7 +109,9 @@ textual's
 timedelta
 trimestriel
 tui
+tz
 ui
+uid
 uids
 uncategorized
 unconfigured

--- a/budget_forecaster/default_config.yaml
+++ b/budget_forecaster/default_config.yaml
@@ -26,8 +26,8 @@ backup:
 #   application_id: "your-application-id"
 #   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
 #   redirect_url: "https://your-redirect-url"
-#   aspsp_name: "the-bank-name"    # bank to link (run `link` to authorize)
 #   aspsp_country: FR
+#   aspsp_name: "the-bank-name"   # optional: skip the bank picker in `link`
 #   account_uid: "..."            # optional: pick one when a consent has several
 #   local_account_name: bnp       # local account the sync merges into
 # logging:  # Override default logging (~/.local/share/budget-forecaster/budget-forecaster.log)

--- a/budget_forecaster/default_config.yaml
+++ b/budget_forecaster/default_config.yaml
@@ -26,7 +26,9 @@ backup:
 #   application_id: "your-application-id"
 #   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
 #   redirect_url: "https://your-redirect-url"
-#   account_uid: "the-account-uid-from-a-prior-consent"
+#   aspsp_name: "the-bank-name"    # bank to link (run `link` to authorize)
+#   aspsp_country: FR
+#   account_uid: "..."            # optional: pick one when a consent has several
 #   local_account_name: bnp       # local account the sync merges into
 # logging:  # Override default logging (~/.local/share/budget-forecaster/budget-forecaster.log)
 #   version: 1

--- a/budget_forecaster/infrastructure/bank_sources/enable_banking/consent.py
+++ b/budget_forecaster/infrastructure/bank_sources/enable_banking/consent.py
@@ -1,0 +1,83 @@
+"""Enable Banking consent: the persisted state of a bank authorization.
+
+A consent ties an authorized session to the accounts it unlocks and to the
+date the bank authorization expires (~180 days for BNP; varies by bank). Its
+status drives when the user must re-authenticate at the bank.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+# Default lead time before expiry at which a consent is flagged as expiring,
+# giving the user time to renew before the session stops working.
+_DEFAULT_EXPIRING_WITHIN = timedelta(days=14)
+
+
+class ConsentStatus(Enum):
+    """Lifecycle state of a consent relative to its expiry date."""
+
+    VALID = "valid"
+    EXPIRING = "expiring"
+    EXPIRED = "expired"
+
+
+@dataclass(frozen=True)
+class Consent:
+    """An authorized Enable Banking session and the accounts it unlocks."""
+
+    session_id: str
+    account_uids: tuple[str, ...]
+    valid_until: datetime
+    aspsp_name: str
+    aspsp_country: str
+    created_at: datetime
+
+    def status(
+        self,
+        now: datetime,
+        expiring_within: timedelta = _DEFAULT_EXPIRING_WITHIN,
+    ) -> ConsentStatus:
+        """Return the status at now.
+
+        EXPIRED once the expiry is reached, EXPIRING within expiring_within
+        of it, VALID otherwise.
+        """
+        remaining = self.valid_until - now
+        if remaining <= timedelta(0):
+            return ConsentStatus.EXPIRED
+        if remaining <= expiring_within:
+            return ConsentStatus.EXPIRING
+        return ConsentStatus.VALID
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "session_id": self.session_id,
+            "account_uids": list(self.account_uids),
+            "valid_until": self.valid_until.isoformat(),
+            "aspsp_name": self.aspsp_name,
+            "aspsp_country": self.aspsp_country,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Consent":
+        """Rebuild a consent from its serialized form."""
+        return cls(
+            session_id=data["session_id"],
+            account_uids=tuple(data["account_uids"]),
+            valid_until=_parse_datetime(data["valid_until"]),
+            aspsp_name=data["aspsp_name"],
+            aspsp_country=data["aspsp_country"],
+            created_at=_parse_datetime(data["created_at"]),
+        )
+
+
+def _parse_datetime(value: str) -> datetime:
+    """Parse an ISO 8601 datetime as an aware UTC value (naive input assumed UTC)."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/budget_forecaster/infrastructure/bank_sources/enable_banking/consent_service.py
+++ b/budget_forecaster/infrastructure/bank_sources/enable_banking/consent_service.py
@@ -1,0 +1,186 @@
+"""Consent lifecycle backend for Enable Banking.
+
+Drives enrollment, persistence, status and renewal on top of
+EnableBankingClient and ConsentStore. Shared by the CLI sync and the
+web enrollment UI; it holds no UI concern (redirect capture lives in the
+caller).
+"""
+
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from budget_forecaster.infrastructure.bank_sources.enable_banking.client import (
+    EnableBankingClient,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent import (
+    Consent,
+    ConsentStatus,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_store import (
+    ConsentStore,
+)
+
+logger = logging.getLogger(__name__)
+
+# BNP grants ~180 days; other banks may cap lower and shorten it on their side.
+_DEFAULT_VALID_DAYS = 180
+
+
+@dataclass(frozen=True)
+class ConsentState:
+    """A consent's status paired with its expiry, for callers to display."""
+
+    status: ConsentStatus
+    valid_until: datetime | None
+
+
+class NoConsentError(RuntimeError):
+    """Raised when an operation needs a consent but none is available."""
+
+
+class ConsentService:
+    """Enroll, persist, inspect and renew an Enable Banking consent."""
+
+    def __init__(self, client: EnableBankingClient, store: ConsentStore) -> None:
+        self._client = client
+        self._store = store
+
+    def list_banks(self, country: str = "FR") -> tuple[dict[str, Any], ...]:
+        """List the banks available for enrollment in a country."""
+        return self._client.list_aspsps(country)
+
+    def start_enrollment(
+        self,
+        aspsp_name: str,
+        country: str = "FR",
+        valid_days: int = _DEFAULT_VALID_DAYS,
+        state: str | None = None,
+    ) -> str:
+        """Start an authorization and return the bank redirect URL.
+
+        The caller sends the user to the URL; the bank redirects back with a
+        code to pass to complete_enrollment. state is echoed back on
+        the redirect for correlation; a random one is generated when omitted.
+        """
+        valid_until = _now() + timedelta(days=valid_days)
+        return self._client.start_authorization(
+            aspsp_name=aspsp_name,
+            country=country,
+            valid_until=_to_api_datetime(valid_until),
+            state=state or secrets.token_urlsafe(16),
+        )
+
+    def complete_enrollment(
+        self, code: str, aspsp_name: str, country: str = "FR"
+    ) -> Consent:
+        """Exchange the authorization code for a session and persist the consent.
+
+        aspsp_name/country identify the bank being linked so a later
+        renewal can target it.
+        """
+        session = self._client.create_session(code)
+        consent = Consent(
+            session_id=session["session_id"],
+            account_uids=_extract_account_uids(session),
+            valid_until=_extract_valid_until(session),
+            aspsp_name=aspsp_name,
+            aspsp_country=country,
+            created_at=_now(),
+        )
+        self._store.save(consent)
+        logger.info(
+            "Stored consent for %s: %d account(s), valid until %s",
+            aspsp_name,
+            len(consent.account_uids),
+            consent.valid_until.date(),
+        )
+        return consent
+
+    def current_consent(self) -> Consent | None:
+        """Return the persisted consent, or None if none is stored."""
+        return self._store.load()
+
+    def state(self) -> ConsentState:
+        """Return the current consent status and expiry.
+
+        A missing consent reads as EXPIRED with no expiry date.
+        """
+        if (consent := self._store.load()) is None:
+            return ConsentState(ConsentStatus.EXPIRED, None)
+        return ConsentState(consent.status(_now()), consent.valid_until)
+
+    def renew(self, state: str | None = None) -> str:
+        """Start a fresh authorization for the stored bank, returning its URL.
+
+        Renewal still needs the user to authenticate at the bank; completion
+        goes through complete_enrollment with the new code.
+        """
+        if (consent := self._store.load()) is None:
+            raise NoConsentError("No consent to renew; enroll first.")
+        return self.start_enrollment(
+            aspsp_name=consent.aspsp_name,
+            country=consent.aspsp_country,
+            state=state,
+        )
+
+    def resolve_account_uid(self, preferred: str | None = None) -> str:
+        """Return the account uid to sync from the active consent.
+
+        Fails when there is no consent, it has expired, or preferred is not
+        among its accounts. With several accounts and no preferred, the
+        selection is ambiguous and rejected.
+        """
+        if (consent := self._store.load()) is None:
+            raise NoConsentError("No consent stored; run enrollment first.")
+        if consent.status(_now()) is ConsentStatus.EXPIRED:
+            raise NoConsentError(
+                f"Consent expired on {consent.valid_until.date()}; renew it."
+            )
+        if preferred is not None:
+            if preferred not in consent.account_uids:
+                raise NoConsentError(
+                    f"Account {preferred!r} is not in the current consent."
+                )
+            return preferred
+        if len(consent.account_uids) == 1:
+            return consent.account_uids[0]
+        raise NoConsentError(
+            "Consent unlocks several accounts; set account_uid in the config."
+        )
+
+
+def _extract_account_uids(session: dict[str, Any]) -> tuple[str, ...]:
+    """Read account uids from a session payload (uid strings or objects)."""
+    accounts = session.get("accounts", [])
+    return tuple(
+        account if isinstance(account, str) else account["uid"] for account in accounts
+    )
+
+
+def _extract_valid_until(session: dict[str, Any]) -> datetime:
+    """Read the granted consent expiry from a session payload."""
+    access = session.get("access", {})
+    if "valid_until" not in access:
+        raise ValueError("Session payload has no access.valid_until")
+    return _parse_api_datetime(access["valid_until"])
+
+
+def _parse_api_datetime(value: str) -> datetime:
+    """Parse an API datetime as aware UTC (naive input assumed UTC)."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _to_api_datetime(value: datetime) -> str:
+    """Format a datetime as the API's ...Z UTC string."""
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now() -> datetime:
+    """Current aware UTC time."""
+    return datetime.now(timezone.utc)

--- a/budget_forecaster/infrastructure/bank_sources/enable_banking/consent_store.py
+++ b/budget_forecaster/infrastructure/bank_sources/enable_banking/consent_store.py
@@ -1,0 +1,59 @@
+"""Persistence for the Enable Banking consent.
+
+The consent lives outside the repository, under the XDG state directory, in a
+file readable only by the user. A single consent is stored at a time.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent import (
+    Consent,
+)
+
+_STATE_SUBDIR = Path("budget-forecaster") / "enable_banking"
+_CONSENT_FILENAME = "consent.json"
+_OWNER_READ_WRITE = stat.S_IRUSR | stat.S_IWUSR
+
+
+class ConsentStore:
+    """Load and persist the current consent as JSON on disk."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @classmethod
+    def default(cls) -> "ConsentStore":
+        """Store under $XDG_STATE_HOME (fallback ~/.local/state)."""
+        return cls(_state_dir() / _STATE_SUBDIR / _CONSENT_FILENAME)
+
+    @property
+    def path(self) -> Path:
+        """Path of the consent file on disk."""
+        return self._path
+
+    def load(self) -> Consent | None:
+        """Return the stored consent, or None if none has been saved."""
+        if not self._path.exists():
+            return None
+        data = json.loads(self._path.read_text(encoding="utf-8"))
+        return Consent.from_dict(data)
+
+    def save(self, consent: Consent) -> None:
+        """Persist the consent, creating the directory and restricting perms."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(consent.to_dict(), indent=2), encoding="utf-8")
+        os.chmod(self._path, _OWNER_READ_WRITE)
+
+    def clear(self) -> None:
+        """Remove the stored consent if present."""
+        self._path.unlink(missing_ok=True)
+
+
+def _state_dir() -> Path:
+    """Resolve the XDG state base directory."""
+    if xdg_state := os.environ.get("XDG_STATE_HOME"):
+        return Path(xdg_state)
+    return Path.home() / ".local" / "state"

--- a/budget_forecaster/infrastructure/config.py
+++ b/budget_forecaster/infrastructure/config.py
@@ -42,13 +42,17 @@ class BackupConfig(NamedTuple):
 
 
 class EnableBankingConfig(NamedTuple):
-    """Credentials and target account for the Enable Banking API source."""
+    """Credentials and enrollment target for the Enable Banking API source."""
 
     application_id: str
     private_key_path: Path
     redirect_url: str
-    account_uid: str
-    """Enable Banking account identifier to sync (from a prior consent)."""
+    aspsp_name: str | None = None
+    """Bank to enroll (Enable Banking ASPSP name); required to link a consent."""
+    aspsp_country: str = "FR"
+    account_uid: str | None = None
+    """Account to sync when a consent unlocks several; the persisted consent is
+    the source of truth otherwise."""
     local_account_name: str = "bnp"
     """Local account the synced operations merge into."""
 
@@ -115,7 +119,9 @@ class Config:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
                     application_id=eb_cfg["application_id"],
                     private_key_path=Path(eb_cfg["private_key_path"]).expanduser(),
                     redirect_url=eb_cfg["redirect_url"],
-                    account_uid=eb_cfg["account_uid"],
+                    aspsp_name=eb_cfg.get("aspsp_name"),
+                    aspsp_country=eb_cfg.get("aspsp_country", "FR"),
+                    account_uid=eb_cfg.get("account_uid"),
                     local_account_name=eb_cfg.get("local_account_name", "bnp"),
                 )
             # Parse the account registry (local name -> external id)

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 from budget_forecaster.infrastructure.bank_sources.enable_banking.client import (
     EnableBankingClient,
@@ -108,34 +109,52 @@ def _run_sync(config_path: Path) -> None:
             repository.close()
 
 
+def _choose_aspsp_name(banks: tuple[dict[str, Any], ...], selection: str) -> str:
+    """Return the bank name for a 1-based selection string, raising on a bad one."""
+    try:
+        index = int(selection)
+    except ValueError as error:
+        raise ValueError(f"Not a number: {selection!r}") from error
+    if not 1 <= index <= len(banks):
+        raise ValueError(f"Selection out of range: {index}")
+    return banks[index - 1]["name"]
+
+
+def _select_bank(consent_service: ConsentService, country: str) -> str:
+    """List the banks and prompt the user to pick one; return its name."""
+    if not (banks := consent_service.list_banks(country)):
+        print(f"No banks available for {country}.", file=sys.stderr)
+        sys.exit(1)
+    print(f"Available banks ({country}):")
+    for position, bank in enumerate(banks, start=1):
+        print(f"  {position}. {bank['name']}")
+    try:
+        return _choose_aspsp_name(banks, input(f"Select a bank [1-{len(banks)}]: "))
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        sys.exit(1)
+
+
 def _run_link(config_path: Path) -> None:
-    """Link a bank via manual copy-paste: print the URL, read the code, persist."""
+    """Link a bank via manual copy-paste: pick the bank, print the URL, read the code."""
     config = Config()
     config.parse(config_path)
     config.setup_logging()
     enable_banking = _require_enable_banking(config)
-    if enable_banking.aspsp_name is None:
-        print(
-            "No bank to link. Set 'aspsp_name' in the enable_banking config.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     consent_service = ConsentService(
         _build_client(enable_banking), ConsentStore.default()
     )
-    url = consent_service.start_enrollment(
-        enable_banking.aspsp_name, enable_banking.aspsp_country
-    )
+    country = enable_banking.aspsp_country
+    aspsp_name = enable_banking.aspsp_name or _select_bank(consent_service, country)
+
+    url = consent_service.start_enrollment(aspsp_name, country)
     print("Open this URL, authenticate at your bank, then paste the returned code:")
     print(url)
     if not (code := input("code: ").strip()):
         print("No code provided.", file=sys.stderr)
         sys.exit(1)
 
-    consent = consent_service.complete_enrollment(
-        code, enable_banking.aspsp_name, enable_banking.aspsp_country
-    )
+    consent = consent_service.complete_enrollment(code, aspsp_name, country)
     print(
         f"Linked {consent.aspsp_name}: {len(consent.account_uids)} account(s), "
         f"consent valid until {consent.valid_until.date()}."

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -8,11 +8,18 @@ from pathlib import Path
 from budget_forecaster.infrastructure.bank_sources.enable_banking.client import (
     EnableBankingClient,
 )
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_service import (
+    ConsentService,
+    NoConsentError,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_store import (
+    ConsentStore,
+)
 from budget_forecaster.infrastructure.bank_sources.enable_banking.source import (
     EnableBankingSource,
 )
 from budget_forecaster.infrastructure.bootstrap import open_repository
-from budget_forecaster.infrastructure.config import Config
+from budget_forecaster.infrastructure.config import Config, EnableBankingConfig
 from budget_forecaster.infrastructure.persistence.persistent_account import (
     PersistentAccount,
 )
@@ -40,29 +47,41 @@ def _create_default_config(config_path: Path) -> None:
     config_path.write_text(template_content, encoding="utf-8")
 
 
-def _run_sync(config_path: Path) -> None:
-    """Sync the configured Enable Banking account into the local database."""
-    config = Config()
-    config.parse(config_path)
-    config.setup_logging()
-
-    if (enable_banking := config.enable_banking) is None:
+def _require_enable_banking(config: Config) -> EnableBankingConfig:
+    """Return the Enable Banking config or exit with a helpful message."""
+    if config.enable_banking is None:
         print(
             "Enable Banking is not configured. "
             "Add an 'enable_banking' section to your config file.",
             file=sys.stderr,
         )
         sys.exit(1)
+    return config.enable_banking
+
+
+def _build_client(enable_banking: EnableBankingConfig) -> EnableBankingClient:
+    """Build the Enable Banking client from the configured credentials."""
+    return EnableBankingClient(
+        enable_banking.application_id,
+        enable_banking.private_key_path,
+        enable_banking.redirect_url,
+    )
+
+
+def _run_sync(config_path: Path) -> None:
+    """Sync the consented Enable Banking account into the local database."""
+    config = Config()
+    config.parse(config_path)
+    config.setup_logging()
+    enable_banking = _require_enable_banking(config)
+    client = _build_client(enable_banking)
+    consent_service = ConsentService(client, ConsentStore.default())
 
     repository = None
     try:
+        account_uid = consent_service.resolve_account_uid(enable_banking.account_uid)
         repository = open_repository(config)
         persistent_account = PersistentAccount(repository)
-        client = EnableBankingClient(
-            enable_banking.application_id,
-            enable_banking.private_key_path,
-            enable_banking.redirect_url,
-        )
         source = EnableBankingSource(client, name=enable_banking.local_account_name)
         sync_use_case = SyncUseCase(
             BankSyncService(persistent_account, source, config.accounts),
@@ -70,13 +89,16 @@ def _run_sync(config_path: Path) -> None:
             OperationLinkService(repository),
             MatcherCache(ForecastService(persistent_account, repository)),
         )
-        stats = sync_use_case.sync(enable_banking.account_uid)
+        stats = sync_use_case.sync(account_uid)
         account = persistent_account.account
         print(
             f"Synced {source.name}: {stats.new_operations} new, "
             f"{stats.duplicates_skipped} duplicates skipped. "
             f"Balance: {account.balance:.2f} {account.currency}"
         )
+    except NoConsentError as error:
+        print(f"{error}", file=sys.stderr)
+        sys.exit(1)
     except Exception:  # pylint: disable=broad-except
         logger.exception("Sync failed")
         print("Sync failed. See the log for details.", file=sys.stderr)
@@ -84,6 +106,56 @@ def _run_sync(config_path: Path) -> None:
     finally:
         if repository is not None:
             repository.close()
+
+
+def _run_link(config_path: Path) -> None:
+    """Link a bank via manual copy-paste: print the URL, read the code, persist."""
+    config = Config()
+    config.parse(config_path)
+    config.setup_logging()
+    enable_banking = _require_enable_banking(config)
+    if enable_banking.aspsp_name is None:
+        print(
+            "No bank to link. Set 'aspsp_name' in the enable_banking config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    consent_service = ConsentService(
+        _build_client(enable_banking), ConsentStore.default()
+    )
+    url = consent_service.start_enrollment(
+        enable_banking.aspsp_name, enable_banking.aspsp_country
+    )
+    print("Open this URL, authenticate at your bank, then paste the returned code:")
+    print(url)
+    if not (code := input("code: ").strip()):
+        print("No code provided.", file=sys.stderr)
+        sys.exit(1)
+
+    consent = consent_service.complete_enrollment(
+        code, enable_banking.aspsp_name, enable_banking.aspsp_country
+    )
+    print(
+        f"Linked {consent.aspsp_name}: {len(consent.account_uids)} account(s), "
+        f"consent valid until {consent.valid_until.date()}."
+    )
+
+
+def _run_consent_status(config_path: Path) -> None:
+    """Print the current consent status and expiry date."""
+    config = Config()
+    config.parse(config_path)
+    config.setup_logging()
+    enable_banking = _require_enable_banking(config)
+    consent_service = ConsentService(
+        _build_client(enable_banking), ConsentStore.default()
+    )
+    state = consent_service.state()
+    if state.valid_until is None:
+        print("No consent stored. Run 'link' to authorize a bank.")
+        return
+    print(f"Consent {state.status.value}, valid until {state.valid_until.date()}.")
 
 
 def main() -> None:
@@ -102,6 +174,12 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("sync", help="Sync a linked bank account via Enable Banking")
+    subparsers.add_parser(
+        "link", help="Link a bank via Enable Banking (manual code copy-paste)"
+    )
+    subparsers.add_parser(
+        "consent-status", help="Show the Enable Banking consent status and expiry"
+    )
     args = parser.parse_args()
 
     config_path = args.config.expanduser()
@@ -114,6 +192,10 @@ def main() -> None:
 
     if args.command == "sync":
         _run_sync(config_path)
+    elif args.command == "link":
+        _run_link(config_path)
+    elif args.command == "consent-status":
+        _run_consent_status(config_path)
     else:
         run_app(config_path)
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -55,8 +55,8 @@ backup:
 #   application_id: "your-application-id"
 #   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
 #   redirect_url: "https://your-redirect-url"
-#   aspsp_name: "the-bank-name"   # bank to link (run `link` to authorize)
 #   aspsp_country: FR
+#   aspsp_name: "the-bank-name"   # optional: skip the bank picker in `link`
 #   account_uid: "..."            # optional: pick one when a consent has several
 #   local_account_name: bnp       # local account the sync merges into
 
@@ -105,7 +105,8 @@ budget-forecaster sync            # import transactions and balance
 budget-forecaster consent-status  # show whether the consent is valid/expiring/expired
 ```
 
-`link` uses `aspsp_name`/`aspsp_country` to know which bank to authorize. It stores the
+`link` lists the banks available in `aspsp_country` and lets you pick yours, so you
+never type an exact bank name (set `aspsp_name` to skip the picker). It stores the
 resulting session and its expiry outside the repo, under
 `$XDG_STATE_HOME/budget-forecaster` (falling back to `~/.local/state`), readable only by
 you. `sync` reads that stored consent, so you never paste an account id by hand.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -55,7 +55,9 @@ backup:
 #   application_id: "your-application-id"
 #   private_key_path: ~/.config/budget-forecaster/enable_banking_key.pem
 #   redirect_url: "https://your-redirect-url"
-#   account_uid: "the-account-uid-from-a-prior-consent"
+#   aspsp_name: "the-bank-name"   # bank to link (run `link` to authorize)
+#   aspsp_country: FR
+#   account_uid: "..."            # optional: pick one when a consent has several
 #   local_account_name: bnp       # local account the sync merges into
 
 # Optional - Python dictConfig format for logging
@@ -91,24 +93,35 @@ backup:
 ## Syncing bank data (Enable Banking)
 
 The `sync` command imports transactions and the account balance directly from the bank
-through Enable Banking, as an alternative to loading exported files:
+through Enable Banking, as an alternative to loading exported files.
+
+Linking a bank needs a consent that the bank issues after you authenticate in a browser
+(valid ~180 days for BNP; varies by bank). Authorize the bank once with `link`, then
+sync as often as you like:
 
 ```bash
-budget-forecaster sync
+budget-forecaster link            # prints a URL; authenticate, paste back the code
+budget-forecaster sync            # import transactions and balance
+budget-forecaster consent-status  # show whether the consent is valid/expiring/expired
 ```
 
-It reads the `enable_banking` section from the config, fetches the account identified by
-`account_uid`, and merges the operations into the `local_account_name` account.
-Re-running the command is safe: already-imported operations are skipped, and operations
-that overlap with a manual file import are reconciled rather than duplicated.
+`link` uses `aspsp_name`/`aspsp_country` to know which bank to authorize. It stores the
+resulting session and its expiry outside the repo, under
+`$XDG_STATE_HOME/budget-forecaster` (falling back to `~/.local/state`), readable only by
+you. `sync` reads that stored consent, so you never paste an account id by hand.
+`account_uid` is only needed to pick one account when a single consent unlocks several.
+When the consent expires, run `link` again to renew it.
+
+Re-running `sync` is safe: already-imported operations are skipped, and operations that
+overlap with a manual file import are reconciled rather than duplicated.
 
 When an account is declared in the `accounts` registry, its external id (the IBAN)
 becomes its stable identity: file imports and API syncs of the same account reconcile by
 that id, and several accounts of the same bank stay distinct. Accounts left undeclared
 keep working, matched by their name.
 
-Obtaining the `application_id`, private key, `redirect_url`, and `account_uid` requires
-a one-time Enable Banking setup, documented separately.
+Obtaining the `application_id`, private key and `redirect_url` requires a one-time
+Enable Banking setup, documented separately.
 
 ## Inbox Auto-Detection
 

--- a/tests/infrastructure/bank_sources/enable_banking/test_consent.py
+++ b/tests/infrastructure/bank_sources/enable_banking/test_consent.py
@@ -1,0 +1,91 @@
+"""Tests for the Enable Banking consent model."""
+
+from datetime import datetime, timedelta, timezone
+
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent import (
+    Consent,
+    ConsentStatus,
+)
+
+_NOW = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _consent(valid_until: datetime) -> Consent:
+    """Build a consent expiring at valid_until."""
+    return Consent(
+        session_id="s1",
+        account_uids=("acc-1",),
+        valid_until=valid_until,
+        aspsp_name="BNP",
+        aspsp_country="FR",
+        created_at=_NOW,
+    )
+
+
+def test_status_valid_far_from_expiry() -> None:
+    """A consent well before its expiry is valid."""
+    consent = _consent(_NOW + timedelta(days=90))
+
+    assert consent.status(_NOW) is ConsentStatus.VALID
+
+
+def test_status_expiring_within_threshold() -> None:
+    """A consent within the expiring window is flagged as expiring."""
+    consent = _consent(_NOW + timedelta(days=10))
+
+    assert consent.status(_NOW, expiring_within=timedelta(days=14)) is (
+        ConsentStatus.EXPIRING
+    )
+
+
+def test_status_expiring_at_threshold_boundary() -> None:
+    """Exactly at the threshold still counts as expiring, not valid."""
+    consent = _consent(_NOW + timedelta(days=14))
+
+    assert consent.status(_NOW, expiring_within=timedelta(days=14)) is (
+        ConsentStatus.EXPIRING
+    )
+
+
+def test_status_expired_at_expiry_instant() -> None:
+    """A consent is expired once the expiry instant is reached."""
+    consent = _consent(_NOW)
+
+    assert consent.status(_NOW) is ConsentStatus.EXPIRED
+
+
+def test_status_expired_after_expiry() -> None:
+    """A consent past its expiry is expired."""
+    consent = _consent(_NOW - timedelta(days=1))
+
+    assert consent.status(_NOW) is ConsentStatus.EXPIRED
+
+
+def test_round_trip_serialization_preserves_fields() -> None:
+    """to_dict/from_dict preserves every field, including tz-aware datetimes."""
+    consent = Consent(
+        session_id="s1",
+        account_uids=("acc-1", "acc-2"),
+        valid_until=datetime(2026, 12, 31, 23, 59, tzinfo=timezone.utc),
+        aspsp_name="BNP",
+        aspsp_country="FR",
+        created_at=_NOW,
+    )
+
+    assert Consent.from_dict(consent.to_dict()) == consent
+
+
+def test_from_dict_reads_trailing_z_datetime() -> None:
+    """A stored ...Z expiry is parsed back as an aware UTC datetime."""
+    data = {
+        "session_id": "s1",
+        "account_uids": ["acc-1"],
+        "valid_until": "2026-12-31T00:00:00Z",
+        "aspsp_name": "BNP",
+        "aspsp_country": "FR",
+        "created_at": "2026-07-01T00:00:00Z",
+    }
+
+    consent = Consent.from_dict(data)
+
+    assert consent.valid_until == datetime(2026, 12, 31, tzinfo=timezone.utc)

--- a/tests/infrastructure/bank_sources/enable_banking/test_consent_service.py
+++ b/tests/infrastructure/bank_sources/enable_banking/test_consent_service.py
@@ -1,0 +1,229 @@
+"""Tests for the Enable Banking consent service."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent import (
+    Consent,
+    ConsentStatus,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_service import (
+    ConsentService,
+    NoConsentError,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_store import (
+    ConsentStore,
+)
+
+
+def _store(tmp_path: Path) -> ConsentStore:
+    """Build a store backed by a temporary file."""
+    return ConsentStore(tmp_path / "consent.json")
+
+
+def _consent(account_uids: tuple[str, ...], valid_until: datetime) -> Consent:
+    """Build a consent with the given accounts and expiry."""
+    return Consent(
+        session_id="s1",
+        account_uids=account_uids,
+        valid_until=valid_until,
+        aspsp_name="BNP",
+        aspsp_country="FR",
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def _future() -> datetime:
+    """An expiry comfortably in the future."""
+    return datetime.now(timezone.utc) + timedelta(days=90)
+
+
+def _past() -> datetime:
+    """An expiry in the past."""
+    return datetime.now(timezone.utc) - timedelta(days=1)
+
+
+def test_list_banks_delegates_to_client(tmp_path: Path) -> None:
+    """list_banks returns the client's ASPSPs for the country."""
+    client = MagicMock()
+    client.list_aspsps.return_value = ({"name": "BNP"},)
+    service = ConsentService(client, _store(tmp_path))
+
+    assert service.list_banks("FR") == ({"name": "BNP"},)
+    client.list_aspsps.assert_called_once_with("FR")
+
+
+def test_start_enrollment_requests_future_expiry_and_state(tmp_path: Path) -> None:
+    """start_enrollment asks the bank for a future expiry and a correlation state."""
+    client = MagicMock()
+    client.start_authorization.return_value = "https://bank.example/consent"
+    service = ConsentService(client, _store(tmp_path))
+
+    url = service.start_enrollment("BNP", "FR")
+
+    assert url == "https://bank.example/consent"
+    call = client.start_authorization.call_args.kwargs
+    assert call["aspsp_name"] == "BNP"
+    assert call["country"] == "FR"
+    assert call["state"]
+    assert call["valid_until"].endswith("Z")
+    requested = datetime.fromisoformat(call["valid_until"])
+    assert requested > datetime.now(timezone.utc)
+
+
+def test_complete_enrollment_persists_consent_from_uid_strings(
+    tmp_path: Path,
+) -> None:
+    """A session with uid strings is stored with its accounts and expiry."""
+    client = MagicMock()
+    client.create_session.return_value = {
+        "session_id": "sess-9",
+        "accounts": ["acc-1", "acc-2"],
+        "access": {"valid_until": "2026-12-31T00:00:00Z"},
+    }
+    store = _store(tmp_path)
+    service = ConsentService(client, store)
+
+    consent = service.complete_enrollment("auth-code", "BNP", "FR")
+
+    assert consent.session_id == "sess-9"
+    assert consent.account_uids == ("acc-1", "acc-2")
+    assert consent.valid_until == datetime(2026, 12, 31, tzinfo=timezone.utc)
+    assert store.load() == consent
+    client.create_session.assert_called_once_with("auth-code")
+
+
+def test_complete_enrollment_reads_uid_objects(tmp_path: Path) -> None:
+    """Account uids given as objects are read from their uid field."""
+    client = MagicMock()
+    client.create_session.return_value = {
+        "session_id": "sess-9",
+        "accounts": [{"uid": "acc-1"}],
+        "access": {"valid_until": "2026-12-31T00:00:00Z"},
+    }
+    service = ConsentService(client, _store(tmp_path))
+
+    consent = service.complete_enrollment("auth-code", "BNP")
+
+    assert consent.account_uids == ("acc-1",)
+
+
+def test_complete_enrollment_rejects_session_without_expiry(tmp_path: Path) -> None:
+    """A session missing access.valid_until is an error, not a stored consent."""
+    client = MagicMock()
+    client.create_session.return_value = {
+        "session_id": "sess-9",
+        "accounts": ["acc-1"],
+    }
+    store = _store(tmp_path)
+    service = ConsentService(client, store)
+
+    with pytest.raises(ValueError):
+        service.complete_enrollment("auth-code", "BNP")
+    assert store.load() is None
+
+
+def test_state_reports_expired_when_no_consent(tmp_path: Path) -> None:
+    """With no stored consent the state is expired with no expiry date."""
+    service = ConsentService(MagicMock(), _store(tmp_path))
+
+    state = service.state()
+
+    assert state.status is ConsentStatus.EXPIRED
+    assert state.valid_until is None
+
+
+def test_state_reports_stored_consent_status(tmp_path: Path) -> None:
+    """A stored valid consent surfaces its status and expiry."""
+    store = _store(tmp_path)
+    consent = _consent(("acc-1",), _future())
+    store.save(consent)
+    service = ConsentService(MagicMock(), store)
+
+    state = service.state()
+
+    assert state.status is ConsentStatus.VALID
+    assert state.valid_until == consent.valid_until
+
+
+def test_renew_starts_authorization_for_stored_bank(tmp_path: Path) -> None:
+    """renew opens a fresh authorization targeting the stored bank."""
+    client = MagicMock()
+    client.start_authorization.return_value = "https://bank.example/renew"
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1",), _future()))
+    service = ConsentService(client, store)
+
+    url = service.renew()
+
+    assert url == "https://bank.example/renew"
+    call = client.start_authorization.call_args.kwargs
+    assert call["aspsp_name"] == "BNP"
+    assert call["country"] == "FR"
+
+
+def test_renew_without_consent_raises(tmp_path: Path) -> None:
+    """Renewing with nothing stored raises."""
+    service = ConsentService(MagicMock(), _store(tmp_path))
+
+    with pytest.raises(NoConsentError):
+        service.renew()
+
+
+def test_resolve_account_uid_returns_single_account(tmp_path: Path) -> None:
+    """With one account and no preference, that account is resolved."""
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1",), _future()))
+    service = ConsentService(MagicMock(), store)
+
+    assert service.resolve_account_uid() == "acc-1"
+
+
+def test_resolve_account_uid_honours_preferred(tmp_path: Path) -> None:
+    """A preferred account present in the consent is resolved as-is."""
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1", "acc-2"), _future()))
+    service = ConsentService(MagicMock(), store)
+
+    assert service.resolve_account_uid("acc-2") == "acc-2"
+
+
+def test_resolve_account_uid_rejects_unknown_preferred(tmp_path: Path) -> None:
+    """A preferred account absent from the consent is rejected."""
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1",), _future()))
+    service = ConsentService(MagicMock(), store)
+
+    with pytest.raises(NoConsentError):
+        service.resolve_account_uid("acc-9")
+
+
+def test_resolve_account_uid_rejects_ambiguous_selection(tmp_path: Path) -> None:
+    """Several accounts and no preference is ambiguous and rejected."""
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1", "acc-2"), _future()))
+    service = ConsentService(MagicMock(), store)
+
+    with pytest.raises(NoConsentError):
+        service.resolve_account_uid()
+
+
+def test_resolve_account_uid_rejects_expired_consent(tmp_path: Path) -> None:
+    """An expired consent cannot resolve an account to sync."""
+    store = _store(tmp_path)
+    store.save(_consent(("acc-1",), _past()))
+    service = ConsentService(MagicMock(), store)
+
+    with pytest.raises(NoConsentError):
+        service.resolve_account_uid()
+
+
+def test_resolve_account_uid_without_consent_raises(tmp_path: Path) -> None:
+    """Resolving with nothing stored raises."""
+    service = ConsentService(MagicMock(), _store(tmp_path))
+
+    with pytest.raises(NoConsentError):
+        service.resolve_account_uid()

--- a/tests/infrastructure/bank_sources/enable_banking/test_consent_store.py
+++ b/tests/infrastructure/bank_sources/enable_banking/test_consent_store.py
@@ -1,0 +1,111 @@
+"""Tests for the Enable Banking consent store."""
+
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent import (
+    Consent,
+)
+from budget_forecaster.infrastructure.bank_sources.enable_banking.consent_store import (
+    ConsentStore,
+)
+
+
+def _consent() -> Consent:
+    """Build a sample consent."""
+    return Consent(
+        session_id="s1",
+        account_uids=("acc-1",),
+        valid_until=datetime(2026, 12, 31, tzinfo=timezone.utc),
+        aspsp_name="BNP",
+        aspsp_country="FR",
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_load_returns_none_when_absent(tmp_path: Path) -> None:
+    """Loading with no stored file returns None."""
+    store = ConsentStore(tmp_path / "consent.json")
+
+    assert store.load() is None
+
+
+def test_save_then_load_round_trip(tmp_path: Path) -> None:
+    """A saved consent reloads identically."""
+    store = ConsentStore(tmp_path / "nested" / "consent.json")
+    consent = _consent()
+
+    store.save(consent)
+
+    assert store.load() == consent
+
+
+def test_save_creates_parent_directory(tmp_path: Path) -> None:
+    """Saving creates missing parent directories."""
+    store = ConsentStore(tmp_path / "a" / "b" / "consent.json")
+
+    store.save(_consent())
+
+    assert store.path.exists()
+
+
+def test_save_restricts_permissions_to_owner(tmp_path: Path) -> None:
+    """The stored file is readable and writable only by its owner."""
+    store = ConsentStore(tmp_path / "consent.json")
+
+    store.save(_consent())
+
+    mode = stat.S_IMODE(store.path.stat().st_mode)
+    assert mode == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_clear_removes_stored_consent(tmp_path: Path) -> None:
+    """Clearing deletes the file and load returns None afterwards."""
+    store = ConsentStore(tmp_path / "consent.json")
+    store.save(_consent())
+
+    store.clear()
+
+    assert store.load() is None
+
+
+def test_clear_is_a_noop_when_absent(tmp_path: Path) -> None:
+    """Clearing with no stored file does not raise."""
+    store = ConsentStore(tmp_path / "consent.json")
+
+    store.clear()
+
+
+def test_default_uses_xdg_state_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default store lives under $XDG_STATE_HOME when set."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    store = ConsentStore.default()
+
+    assert store.path == (
+        tmp_path / "budget-forecaster" / "enable_banking" / "consent.json"
+    )
+
+
+def test_default_falls_back_to_local_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without $XDG_STATE_HOME the default store lives under ~/.local/state."""
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    store = ConsentStore.default()
+
+    assert store.path == (
+        tmp_path
+        / ".local"
+        / "state"
+        / "budget-forecaster"
+        / "enable_banking"
+        / "consent.json"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,13 @@
 """Tests for the CLI entry point."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from budget_forecaster import main
+
+_BANKS = ({"name": "BNP Paribas"}, {"name": "Boursorama"})
 
 
 def test_sync_without_enable_banking_exits(
@@ -30,3 +33,84 @@ def test_sync_without_enable_banking_exits(
 
     assert exc_info.value.code == 1
     assert "Enable Banking is not configured" in capsys.readouterr().err
+
+
+def _write_eb_config(tmp_path: Path) -> Path:
+    """Write a config with an Enable Banking section and no aspsp_name."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"database_path: {tmp_path / 'x.db'}\n"
+        'account_name: "Test"\n'
+        "account_currency: EUR\n"
+        "enable_banking:\n"
+        '  application_id: "app-1"\n'
+        f"  private_key_path: {tmp_path / 'key.pem'}\n"
+        '  redirect_url: "https://localhost/callback"\n',
+        encoding="utf-8",
+    )
+    return config_file
+
+
+def _prime_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, inputs: list[str]
+) -> MagicMock:
+    """Set up the link command with a mock client and scripted user inputs."""
+    monkeypatch.setattr(main.Config, "setup_logging", lambda self: None)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    client = MagicMock()
+    client.list_aspsps.return_value = _BANKS
+    client.start_authorization.return_value = "https://bank.example/consent"
+    client.create_session.return_value = {
+        "session_id": "sess-1",
+        "accounts": ["acc-1"],
+        "access": {"valid_until": "2026-12-31T00:00:00Z"},
+    }
+    monkeypatch.setattr(main, "_build_client", lambda _config: client)
+
+    answers = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["budget-forecaster", "-c", str(_write_eb_config(tmp_path)), "link"],
+    )
+    return client
+
+
+def test_link_lists_banks_and_persists_consent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """link lists banks, links the picked one, and stores the consent under XDG."""
+    client = _prime_link(tmp_path, monkeypatch, ["1", "the-code"])
+
+    main.main()
+
+    out = capsys.readouterr().out
+    assert "1. BNP Paribas" in out
+    assert "Linked BNP Paribas: 1 account(s)" in out
+    assert client.start_authorization.call_args.kwargs["aspsp_name"] == "BNP Paribas"
+    client.create_session.assert_called_once_with("the-code")
+    consent_file = (
+        tmp_path / "state" / "budget-forecaster" / "enable_banking" / "consent.json"
+    )
+    assert consent_file.exists()
+
+
+@pytest.mark.parametrize("selection", ["9", "abc"], ids=["out-of-range", "non-numeric"])
+def test_link_rejects_invalid_bank_selection(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+) -> None:
+    """An invalid bank pick exits without opening an authorization."""
+    client = _prime_link(tmp_path, monkeypatch, [selection])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.main()
+
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().err
+    client.start_authorization.assert_not_called()


### PR DESCRIPTION
## Summary

Reusable consent backend for Enable Banking, replacing the throwaway consent script and the hardcoded `account_uid`. It owns the session/token lifecycle, secure storage, expiry state and renewal. Consumed by the CLI sync now, and by the web enrollment UI (#300) later.

No new API code: it sits on top of the existing `EnableBankingClient`. No new dependencies (stdlib only).

## What changed

| Piece | Role |
|---|---|
| `Consent` + `ConsentStatus` | Session, unlocked accounts and expiry; status valid / expiring (≤14 d) / expired |
| `ConsentStore` | Persists one consent as JSON under `$XDG_STATE_HOME/budget-forecaster` (fallback `~/.local/state`), file mode `0600` |
| `ConsentService` | Enrollment, status, renewal, account resolution over the client + store |
| CLI | `sync` resolves the account from the stored consent; new `link` (manual copy-paste) and `consent-status` |
| Config | `account_uid` now optional (selector when a consent unlocks several); added `aspsp_name` / `aspsp_country` for enrollment |

The account uid is session-scoped and changes on every re-consent, so the stored consent is now the source of truth for sync (the old hardcoded `account_uid` broke on renewal).

## Decisions (from the issue)

- **Storage location**: XDG state, outside the repo, owner-only perms.
- **Private key**: stays a user-provided `private_key_path` in config (already outside the repo); the backend manages only the session file.
- **Renewal**: the backend drives a fresh authorization; the bank auth step stays human (PSD2), completed via `link` again.

## Test plan

- `test_consent.py` — status at the valid / expiring / boundary / expired edges; serialization round-trip incl. `...Z` datetimes.
- `test_consent_store.py` — save/load round-trip, parent-dir creation, `0600` perms, clear, XDG resolution + fallback.
- `test_consent_service.py` — enrollment (uid strings and objects), missing-expiry rejection, status, renew, account resolution (single / preferred / unknown / ambiguous / expired / none).
- Full suite green (`pytest tests/`); pre-commit (black, ruff, mypy, pylint) clean.

Docs: `docs/user/configuration.md` updated for the new flow and commands. Full one-time setup guide stays in #299.

## Related

- Part of #289
- Blocks #300 (web enrollment UI)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)