### PR TITLE
fix: Reconcile cross-source duplicate operations (file + Enable Banking)

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -18,6 +18,7 @@ bool
 budgetinterface
 cancelled
 cancelling
+categorizer
 cli
 clôturé
 codecov
@@ -43,6 +44,7 @@ deserialized
 dialogs
 dicts
 dir
+dup
 edf
 enum
 enums
@@ -83,6 +85,7 @@ pre
 prs
 prévu
 pytest
+recognised
 recomputation
 recurringdaterange
 relativedelta
@@ -90,6 +93,7 @@ renderable
 renderer
 renderers
 repo
+repointed
 repr
 reproducibility
 revenus

--- a/budget_forecaster/domain/account/aggregated_account.py
+++ b/budget_forecaster/domain/account/aggregated_account.py
@@ -1,14 +1,12 @@
 """Module for aggregating multiple accounts into a single account."""
 from datetime import date
+from functools import partial
 from typing import Iterable, NamedTuple
 
 from budget_forecaster.core.types import ImportStats
 from budget_forecaster.domain.account.account import Account, AccountParameters
+from budget_forecaster.domain.operation import cross_source
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
-
-# Max day gap between a file op and an API op recognised as the same
-# transaction, absorbing the booking-date vs value-date drift.
-_RECONCILE_WINDOW_DAYS = 3
 
 
 def _is_cross_source_duplicate(
@@ -23,10 +21,23 @@ def _is_cross_source_duplicate(
     """
     if (incoming.source_ref is None) == (existing.source_ref is None):
         return False
-    if round(incoming.amount * 100) != round(existing.amount * 100):
-        return False
-    gap = abs((incoming.operation_date - existing.operation_date).days)
-    return gap <= _RECONCILE_WINDOW_DAYS
+    return cross_source.is_amount_date_match(
+        cross_source.amount_cents(incoming.amount),
+        incoming.operation_date,
+        cross_source.amount_cents(existing.amount),
+        existing.operation_date,
+    )
+
+
+def _reconcile_rank(
+    incoming_date: date, existing: tuple[HistoricOperation, ...], index: int
+) -> tuple[int, int]:
+    """Rank a candidate existing op: nearest date first, lowest id to break ties."""
+    candidate = existing[index]
+    return (
+        cross_source.date_gap(incoming_date, candidate.operation_date),
+        candidate.unique_id,
+    )
 
 
 class UpdateResult(NamedTuple):
@@ -103,16 +114,17 @@ class AggregatedAccount:
                 keys.add(operation.source_ref)
             if not keys.isdisjoint(existing_refs):
                 continue
-            match_index = next(
-                (
-                    index
-                    for index, candidate in enumerate(existing)
-                    if index not in reconciled
-                    and _is_cross_source_duplicate(operation, candidate)
-                ),
-                None,
-            )
-            if match_index is not None:
+            candidates = [
+                index
+                for index, candidate in enumerate(existing)
+                if index not in reconciled
+                and _is_cross_source_duplicate(operation, candidate)
+            ]
+            if candidates:
+                match_index = min(
+                    candidates,
+                    key=partial(_reconcile_rank, operation.operation_date, existing),
+                )
                 reconciled.add(match_index)
                 continue
             merged.append(operation)

--- a/budget_forecaster/domain/account/aggregated_account.py
+++ b/budget_forecaster/domain/account/aggregated_account.py
@@ -3,10 +3,21 @@ from datetime import date
 from functools import partial
 from typing import Iterable, NamedTuple
 
-from budget_forecaster.core.types import ImportStats
+from budget_forecaster.core.types import Category, ImportStats, OperationId
 from budget_forecaster.domain.account.account import Account, AccountParameters
 from budget_forecaster.domain.operation import cross_source
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
+
+
+class Reconciliation(NamedTuple):
+    """A cross-source pair collapsed to one op: the dropped op and the kept one.
+
+    The API op is always the one kept; the file op is dropped. Callers use this
+    to move the dropped op's link onto the survivor.
+    """
+
+    dropped_id: OperationId
+    kept_id: OperationId
 
 
 def _is_cross_source_duplicate(
@@ -29,6 +40,14 @@ def _is_cross_source_duplicate(
     )
 
 
+def _matches_known_ref(operation: HistoricOperation, existing_refs: set[str]) -> bool:
+    """Whether the op's reference or content ref already exists (exact dedup)."""
+    keys = {operation.content_ref}
+    if operation.source_ref is not None:
+        keys.add(operation.source_ref)
+    return not keys.isdisjoint(existing_refs)
+
+
 def _reconcile_rank(
     incoming_date: date, existing: tuple[HistoricOperation, ...], index: int
 ) -> tuple[int, int]:
@@ -40,11 +59,45 @@ def _reconcile_rank(
     )
 
 
+def _kept_api_op(
+    file_op: HistoricOperation, api_op: HistoricOperation
+) -> HistoricOperation:
+    """The API op that survives a reconciliation, adopting the file's category.
+
+    The API source carries no category, so the file's is kept; when the file is
+    uncategorized the API's own value stands.
+    """
+    category = (
+        file_op.category
+        if file_op.category != Category.UNCATEGORIZED
+        else api_op.category
+    )
+    if category == api_op.category:
+        return api_op
+    return api_op.replace(category=category)
+
+
+class _MergeResult(NamedTuple):
+    """Merged operations, the reconciled pairs, and the count of genuinely new ops."""
+
+    operations: tuple[HistoricOperation, ...]
+    reconciliations: tuple[Reconciliation, ...]
+    new_count: int
+
+
 class UpdateResult(NamedTuple):
     """Result of updating an account with new operations."""
 
     account: Account
     stats: ImportStats
+    reconciliations: tuple[Reconciliation, ...] = ()
+
+
+class UpsertResult(NamedTuple):
+    """Import statistics plus the cross-source pairs collapsed during the upsert."""
+
+    stats: ImportStats
+    reconciliations: tuple[Reconciliation, ...] = ()
 
 
 class AggregatedAccount:
@@ -95,24 +148,26 @@ class AggregatedAccount:
     def _merge_operations(
         existing: tuple[HistoricOperation, ...],
         incoming: tuple[HistoricOperation, ...],
-    ) -> list[HistoricOperation]:
-        """Append the incoming ops that are not duplicates of an existing one.
+    ) -> _MergeResult:
+        """Merge incoming ops into the existing ones, collapsing duplicates.
 
         An op is a duplicate when its reference or content ref matches an
         existing op (exact key), or when it reconciles with a cross-source op by
-        amount and date. Cross-source matching is one-to-one: each existing op
-        absorbs at most one incoming op, so distinct transactions sharing an
-        amount and date are not collapsed.
+        amount and date. A reconciled pair keeps the API op (dropping the file
+        op) and the API op adopts the file's category. Cross-source matching is
+        one-to-one, so distinct transactions sharing an amount and date are not
+        collapsed.
         """
         existing_refs = {op.source_ref or op.content_ref for op in existing}
         reconciled: set[int] = set()
+        replacements: dict[int, HistoricOperation] = {}
+        dropped: set[int] = set()
+        appended: list[HistoricOperation] = []
+        reconciliations: list[Reconciliation] = []
+        new_count = 0
 
-        merged = list(existing)
         for operation in incoming:
-            keys = {operation.content_ref}
-            if operation.source_ref is not None:
-                keys.add(operation.source_ref)
-            if not keys.isdisjoint(existing_refs):
+            if _matches_known_ref(operation, existing_refs):
                 continue
             candidates = [
                 index
@@ -120,15 +175,41 @@ class AggregatedAccount:
                 if index not in reconciled
                 and _is_cross_source_duplicate(operation, candidate)
             ]
-            if candidates:
-                match_index = min(
-                    candidates,
-                    key=partial(_reconcile_rank, operation.operation_date, existing),
-                )
-                reconciled.add(match_index)
+            if not candidates:
+                appended.append(operation)
+                new_count += 1
                 continue
-            merged.append(operation)
-        return merged
+            match_index = min(
+                candidates,
+                key=partial(_reconcile_rank, operation.operation_date, existing),
+            )
+            reconciled.add(match_index)
+            existing_op = existing[match_index]
+            if existing_op.source_ref is not None:
+                # Existing op is the API record we keep; the incoming file copy
+                # only lends its category.
+                if (
+                    kept := _kept_api_op(file_op=operation, api_op=existing_op)
+                ) is not existing_op:
+                    replacements[match_index] = kept
+                reconciliations.append(
+                    Reconciliation(operation.unique_id, existing_op.unique_id)
+                )
+            else:
+                # Existing op is the file copy we drop; the incoming API op wins.
+                dropped.add(match_index)
+                appended.append(_kept_api_op(file_op=existing_op, api_op=operation))
+                reconciliations.append(
+                    Reconciliation(existing_op.unique_id, operation.unique_id)
+                )
+
+        merged = [
+            replacements.get(index, op)
+            for index, op in enumerate(existing)
+            if index not in dropped
+        ]
+        merged.extend(appended)
+        return _MergeResult(tuple(merged), tuple(reconciliations), new_count)
 
     @staticmethod
     def update_account(
@@ -137,18 +218,18 @@ class AggregatedAccount:
         """Update an existing account with new operations.
 
         Returns:
-            UpdateResult containing the updated account and import statistics.
+            UpdateResult with the updated account, import statistics, and the
+            cross-source pairs collapsed during the merge.
         """
-        operations = AggregatedAccount._merge_operations(
+        merge = AggregatedAccount._merge_operations(
             current_account.operations, new_account.operations
         )
-        new_count = len(operations) - len(current_account.operations)
 
         total_in_file = len(new_account.operations)
         stats = ImportStats(
             total_in_file=total_in_file,
-            new_operations=new_count,
-            duplicates_skipped=total_in_file - new_count,
+            new_operations=merge.new_count,
+            duplicates_skipped=total_in_file - merge.new_count,
         )
 
         # Get balance date
@@ -188,27 +269,34 @@ class AggregatedAccount:
         updated_account = current_account._replace(
             balance=balance,
             balance_date=balance_date,
-            operations=tuple(operations),
+            operations=merge.operations,
             external_id=external_id,
         )
-        return UpdateResult(account=updated_account, stats=stats)
+        return UpdateResult(
+            account=updated_account,
+            stats=stats,
+            reconciliations=merge.reconciliations,
+        )
 
-    def upsert_account(self, account: AccountParameters) -> ImportStats:
+    def upsert_account(self, account: AccountParameters) -> UpsertResult:
         """Add or update an account.
 
         The target is resolved external-id-first, then by name; a new account is
         created when neither matches.
 
         Returns:
-            ImportStats with the number of new and duplicate operations.
+            UpsertResult with import statistics and the cross-source pairs
+            collapsed during the upsert.
         """
         if (match_index := self._find_match_index(account)) is None:
             self._accounts = (*self._accounts, self._create_account(account))
             total = len(account.operations)
-            return ImportStats(
-                total_in_file=total,
-                new_operations=total,
-                duplicates_skipped=0,
+            return UpsertResult(
+                ImportStats(
+                    total_in_file=total,
+                    new_operations=total,
+                    duplicates_skipped=0,
+                )
             )
 
         result = self.update_account(self._accounts[match_index], account)
@@ -216,7 +304,7 @@ class AggregatedAccount:
             result.account if index == match_index else current_account
             for index, current_account in enumerate(self._accounts)
         )
-        return result.stats
+        return UpsertResult(result.stats, result.reconciliations)
 
     def _find_match_index(self, account: AccountParameters) -> int | None:
         """Resolve the target sub-account: external id first, then name.

--- a/budget_forecaster/domain/account/aggregated_account.py
+++ b/budget_forecaster/domain/account/aggregated_account.py
@@ -6,6 +6,28 @@ from budget_forecaster.core.types import ImportStats
 from budget_forecaster.domain.account.account import Account, AccountParameters
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
 
+# Max day gap between a file op and an API op recognised as the same
+# transaction, absorbing the booking-date vs value-date drift.
+_RECONCILE_WINDOW_DAYS = 3
+
+
+def _is_cross_source_duplicate(
+    incoming: HistoricOperation, existing: HistoricOperation
+) -> bool:
+    """Whether a file op and an API op describe the same transaction.
+
+    Falls back to signed amount and a small date window, since the same
+    transaction gets a different description (hence a different content ref)
+    from each source. Cross-source only: exactly one op must carry a
+    source_ref, so two same-source ops sharing amount and date stay distinct.
+    """
+    if (incoming.source_ref is None) == (existing.source_ref is None):
+        return False
+    if round(incoming.amount * 100) != round(existing.amount * 100):
+        return False
+    gap = abs((incoming.operation_date - existing.operation_date).days)
+    return gap <= _RECONCILE_WINDOW_DAYS
+
 
 class UpdateResult(NamedTuple):
     """Result of updating an account with new operations."""
@@ -59,6 +81,44 @@ class AggregatedAccount:
         return self._accounts
 
     @staticmethod
+    def _merge_operations(
+        existing: tuple[HistoricOperation, ...],
+        incoming: tuple[HistoricOperation, ...],
+    ) -> list[HistoricOperation]:
+        """Append the incoming ops that are not duplicates of an existing one.
+
+        An op is a duplicate when its reference or content ref matches an
+        existing op (exact key), or when it reconciles with a cross-source op by
+        amount and date. Cross-source matching is one-to-one: each existing op
+        absorbs at most one incoming op, so distinct transactions sharing an
+        amount and date are not collapsed.
+        """
+        existing_refs = {op.source_ref or op.content_ref for op in existing}
+        reconciled: set[int] = set()
+
+        merged = list(existing)
+        for operation in incoming:
+            keys = {operation.content_ref}
+            if operation.source_ref is not None:
+                keys.add(operation.source_ref)
+            if not keys.isdisjoint(existing_refs):
+                continue
+            match_index = next(
+                (
+                    index
+                    for index, candidate in enumerate(existing)
+                    if index not in reconciled
+                    and _is_cross_source_duplicate(operation, candidate)
+                ),
+                None,
+            )
+            if match_index is not None:
+                reconciled.add(match_index)
+                continue
+            merged.append(operation)
+        return merged
+
+    @staticmethod
     def update_account(
         current_account: Account, new_account: AccountParameters
     ) -> UpdateResult:
@@ -67,23 +127,10 @@ class AggregatedAccount:
         Returns:
             UpdateResult containing the updated account and import statistics.
         """
-        # An op is a duplicate if its reference is already known (API/API
-        # idempotency) or its content ref matches an existing op. An incoming
-        # API op reconciles against an already-stored file op by content; the
-        # reverse (file op incoming, API op already stored) is not reconciled.
-        existing_refs = {
-            operation.source_ref or operation.content_ref
-            for operation in current_account.operations
-        }
-        operations = list(current_account.operations)
-        new_count = 0
-        for operation in new_account.operations:
-            keys = {operation.content_ref}
-            if operation.source_ref is not None:
-                keys.add(operation.source_ref)
-            if keys.isdisjoint(existing_refs):
-                operations.append(operation)
-                new_count += 1
+        operations = AggregatedAccount._merge_operations(
+            current_account.operations, new_account.operations
+        )
+        new_count = len(operations) - len(current_account.operations)
 
         total_in_file = len(new_account.operations)
         stats = ImportStats(

--- a/budget_forecaster/domain/account/aggregated_account.py
+++ b/budget_forecaster/domain/account/aggregated_account.py
@@ -156,7 +156,8 @@ class AggregatedAccount:
         amount and date. A reconciled pair keeps the API op (dropping the file
         op) and the API op adopts the file's category. Cross-source matching is
         one-to-one, so distinct transactions sharing an amount and date are not
-        collapsed.
+        collapsed. Incoming ops are processed in (date, id) order so an
+        ambiguous cluster resolves the same way as the purge migration.
         """
         existing_refs = {op.source_ref or op.content_ref for op in existing}
         reconciled: set[int] = set()
@@ -166,7 +167,9 @@ class AggregatedAccount:
         reconciliations: list[Reconciliation] = []
         new_count = 0
 
-        for operation in incoming:
+        for operation in sorted(
+            incoming, key=lambda op: (op.operation_date, op.unique_id)
+        ):
             if _matches_known_ref(operation, existing_refs):
                 continue
             candidates = [

--- a/budget_forecaster/domain/operation/cross_source.py
+++ b/budget_forecaster/domain/operation/cross_source.py
@@ -1,0 +1,29 @@
+"""Shared cross-source reconciliation parameters and matching primitives.
+
+The same transaction gets a different description from a file export and from
+the API, so a file op and an API op are matched by signed amount and a small
+date window rather than by content. The ingest-time dedup and the purge
+migration both build on these primitives, so their pairing can never drift.
+"""
+from datetime import date
+
+# Max day gap between a file op and an API op recognised as the same transaction,
+# absorbing the booking-date vs value-date drift.
+RECONCILE_WINDOW_DAYS = 3
+
+
+def amount_cents(amount: float) -> int:
+    """Signed amount rounded to whole cents, the unit cross-source matching uses."""
+    return round(amount * 100)
+
+
+def date_gap(reference: date, other: date) -> int:
+    """Absolute day gap; the primary key when ranking reconciliation candidates."""
+    return abs((reference - other).days)
+
+
+def is_amount_date_match(
+    cents_a: int, date_a: date, cents_b: int, date_b: date
+) -> bool:
+    """Whether two ops line up on signed amount and a date within the window."""
+    return cents_a == cents_b and date_gap(date_a, date_b) <= RECONCILE_WINDOW_DAYS

--- a/budget_forecaster/domain/operation/cross_source.py
+++ b/budget_forecaster/domain/operation/cross_source.py
@@ -3,7 +3,8 @@
 The same transaction gets a different description from a file export and from
 the API, so a file op and an API op are matched by signed amount and a small
 date window rather than by content. The ingest-time dedup and the purge
-migration both build on these primitives, so their pairing can never drift.
+migration share these primitives and both drive their greedy match in
+(date, id) order, so they resolve an ambiguous cluster the same way.
 """
 from datetime import date
 

--- a/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
+++ b/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
@@ -12,20 +12,19 @@ import logging
 import sqlite3
 from datetime import date
 from functools import partial
+from typing import NamedTuple
+
+from budget_forecaster.domain.operation import cross_source
 
 logger = logging.getLogger(__name__)
 
-# Kept in sync with the ingest-time reconciliation window.
-_RECONCILE_WINDOW_DAYS = 3
 
-
-class _Op:  # pylint: disable=too-few-public-methods
+class _Op(NamedTuple):
     """An operation row reduced to the fields the pairing needs."""
 
-    def __init__(self, unique_id: int, op_date: date, amount_cents: int) -> None:
-        self.unique_id = unique_id
-        self.op_date = op_date
-        self.amount_cents = amount_cents
+    unique_id: int
+    op_date: date
+    amount_cents: int
 
 
 def run(conn: sqlite3.Connection) -> None:
@@ -45,11 +44,12 @@ def run(conn: sqlite3.Connection) -> None:
 
 def _pairs_for_account(
     conn: sqlite3.Connection, account_id: int
-) -> list[tuple[int, int]]:
+) -> tuple[tuple[int, int], ...]:
     """Greedily pair each API op with a file op of matching amount and date.
 
     Returns (api_unique_id, file_unique_id) pairs; matching is one-to-one so
-    distinct transactions sharing an amount and date are never collapsed.
+    distinct transactions sharing an amount and date are never collapsed. The
+    nearest date wins, mirroring the ingest-time reconciliation.
     """
     file_ops = _load_ops(conn, account_id, with_source_ref=False)
     api_ops = _load_ops(conn, account_id, with_source_ref=True)
@@ -61,25 +61,26 @@ def _pairs_for_account(
             file_op
             for file_op in file_ops
             if file_op.unique_id not in matched_files
-            and file_op.amount_cents == api.amount_cents
-            and abs((api.op_date - file_op.op_date).days) <= _RECONCILE_WINDOW_DAYS
+            and cross_source.is_amount_date_match(
+                file_op.amount_cents, file_op.op_date, api.amount_cents, api.op_date
+            )
         ]
         if not candidates:
             continue
         best = min(candidates, key=partial(_match_key, api.op_date))
         matched_files.add(best.unique_id)
         pairs.append((api.unique_id, best.unique_id))
-    return pairs
+    return tuple(pairs)
 
 
-def _match_key(api_date: date, file_op: "_Op") -> tuple[int, int]:
+def _match_key(api_date: date, file_op: _Op) -> tuple[int, int]:
     """Rank file candidates: nearest date first, lowest id to break ties."""
-    return (abs((api_date - file_op.op_date).days), file_op.unique_id)
+    return (cross_source.date_gap(api_date, file_op.op_date), file_op.unique_id)
 
 
 def _load_ops(
     conn: sqlite3.Connection, account_id: int, with_source_ref: bool
-) -> list[_Op]:
+) -> tuple[_Op, ...]:
     """Load the file ops (no source_ref) or API ops (with source_ref)."""
     predicate = "IS NOT NULL" if with_source_ref else "IS NULL"
     cursor = conn.execute(
@@ -88,34 +89,45 @@ def _load_ops(
         f"ORDER BY date, unique_id",
         (account_id,),
     )
-    return [
+    return tuple(
         _Op(
             unique_id=row["unique_id"],
             op_date=date.fromisoformat(row["date"]),
-            amount_cents=round(row["amount"] * 100),
+            amount_cents=cross_source.amount_cents(row["amount"]),
         )
         for row in cursor.fetchall()
-    ]
+    )
 
 
 def _reassign_manual_link(conn: sqlite3.Connection, from_op: int, to_op: int) -> None:
-    """Move a manual link off the doomed op, unless the survivor already has one.
+    """Move a manual link off the doomed op onto the survivor.
 
-    Automatic links are left to be recomputed by the categorizer.
+    Skips when the doomed op has no manual link. A manual link on the survivor
+    wins and is kept; an automatic one is overwritten, since manual intent
+    outranks a categorizer-derived link.
     """
-    row = conn.execute(
-        "SELECT is_manual FROM operation_links WHERE operation_unique_id = ?",
-        (from_op,),
-    ).fetchone()
-    if row is None or not row["is_manual"]:
+    if not _has_manual_link(conn, from_op):
         return
-    survivor_has_link = conn.execute(
-        "SELECT 1 FROM operation_links WHERE operation_unique_id = ?", (to_op,)
-    ).fetchone()
-    if survivor_has_link is not None:
+    if _has_manual_link(conn, to_op):
+        logger.warning(
+            "Discarding manual link on op %d: survivor op %d is already "
+            "manually linked",
+            from_op,
+            to_op,
+        )
         return
+    conn.execute("DELETE FROM operation_links WHERE operation_unique_id = ?", (to_op,))
     conn.execute(
         "UPDATE operation_links SET operation_unique_id = ? "
         "WHERE operation_unique_id = ?",
         (to_op, from_op),
     )
+
+
+def _has_manual_link(conn: sqlite3.Connection, operation_id: int) -> bool:
+    """Whether the operation carries a manual (user-set) link."""
+    row = conn.execute(
+        "SELECT is_manual FROM operation_links WHERE operation_unique_id = ?",
+        (operation_id,),
+    ).fetchone()
+    return row is not None and bool(row["is_manual"])

--- a/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
+++ b/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
@@ -1,0 +1,121 @@
+"""v9 -> v10: purge cross-source duplicate operations.
+
+Databases populated from a file export and later synced from the Enable Banking
+API hold the same transaction twice: the two sources give it different
+descriptions, so the content-ref dedup never recognised the pair. Each pair is
+collapsed here by keeping the file op and deleting the API copy, matching on
+signed amount and a small date window. A manual link carried only by the API
+copy is repointed to the surviving file op so no user intent is lost.
+"""
+
+import logging
+import sqlite3
+from datetime import date
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+# Kept in sync with the ingest-time reconciliation window.
+_RECONCILE_WINDOW_DAYS = 3
+
+
+class _Op:  # pylint: disable=too-few-public-methods
+    """An operation row reduced to the fields the pairing needs."""
+
+    def __init__(self, unique_id: int, op_date: date, amount_cents: int) -> None:
+        self.unique_id = unique_id
+        self.op_date = op_date
+        self.amount_cents = amount_cents
+
+
+def run(conn: sqlite3.Connection) -> None:
+    """Collapse cross-source duplicate operations across every account."""
+    purged = 0
+    for (account_id,) in conn.execute("SELECT id FROM accounts").fetchall():
+        for api_id, file_id in _pairs_for_account(conn, account_id):
+            _reassign_manual_link(conn, from_op=api_id, to_op=file_id)
+            conn.execute(
+                "DELETE FROM operation_links WHERE operation_unique_id = ?", (api_id,)
+            )
+            conn.execute("DELETE FROM operations WHERE unique_id = ?", (api_id,))
+            purged += 1
+    conn.commit()
+    logger.info("Purged %d cross-source duplicate operations", purged)
+
+
+def _pairs_for_account(
+    conn: sqlite3.Connection, account_id: int
+) -> list[tuple[int, int]]:
+    """Greedily pair each API op with a file op of matching amount and date.
+
+    Returns (api_unique_id, file_unique_id) pairs; matching is one-to-one so
+    distinct transactions sharing an amount and date are never collapsed.
+    """
+    file_ops = _load_ops(conn, account_id, with_source_ref=False)
+    api_ops = _load_ops(conn, account_id, with_source_ref=True)
+
+    matched_files: set[int] = set()
+    pairs: list[tuple[int, int]] = []
+    for api in api_ops:
+        candidates = [
+            file_op
+            for file_op in file_ops
+            if file_op.unique_id not in matched_files
+            and file_op.amount_cents == api.amount_cents
+            and abs((api.op_date - file_op.op_date).days) <= _RECONCILE_WINDOW_DAYS
+        ]
+        if not candidates:
+            continue
+        best = min(candidates, key=partial(_match_key, api.op_date))
+        matched_files.add(best.unique_id)
+        pairs.append((api.unique_id, best.unique_id))
+    return pairs
+
+
+def _match_key(api_date: date, file_op: "_Op") -> tuple[int, int]:
+    """Rank file candidates: nearest date first, lowest id to break ties."""
+    return (abs((api_date - file_op.op_date).days), file_op.unique_id)
+
+
+def _load_ops(
+    conn: sqlite3.Connection, account_id: int, with_source_ref: bool
+) -> list[_Op]:
+    """Load the file ops (no source_ref) or API ops (with source_ref)."""
+    predicate = "IS NOT NULL" if with_source_ref else "IS NULL"
+    cursor = conn.execute(
+        f"SELECT unique_id, date, amount FROM operations "  # noqa: S608
+        f"WHERE account_id = ? AND source_ref {predicate} "
+        f"ORDER BY date, unique_id",
+        (account_id,),
+    )
+    return [
+        _Op(
+            unique_id=row["unique_id"],
+            op_date=date.fromisoformat(row["date"]),
+            amount_cents=round(row["amount"] * 100),
+        )
+        for row in cursor.fetchall()
+    ]
+
+
+def _reassign_manual_link(conn: sqlite3.Connection, from_op: int, to_op: int) -> None:
+    """Move a manual link off the doomed op, unless the survivor already has one.
+
+    Automatic links are left to be recomputed by the categorizer.
+    """
+    row = conn.execute(
+        "SELECT is_manual FROM operation_links WHERE operation_unique_id = ?",
+        (from_op,),
+    ).fetchone()
+    if row is None or not row["is_manual"]:
+        return
+    survivor_has_link = conn.execute(
+        "SELECT 1 FROM operation_links WHERE operation_unique_id = ?", (to_op,)
+    ).fetchone()
+    if survivor_has_link is not None:
+        return
+    conn.execute(
+        "UPDATE operation_links SET operation_unique_id = ? "
+        "WHERE operation_unique_id = ?",
+        (to_op, from_op),
+    )

--- a/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
+++ b/budget_forecaster/infrastructure/persistence/migrations/v010_purge_cross_source_duplicates.py
@@ -3,9 +3,11 @@
 Databases populated from a file export and later synced from the Enable Banking
 API hold the same transaction twice: the two sources give it different
 descriptions, so the content-ref dedup never recognised the pair. Each pair is
-collapsed here by keeping the file op and deleting the API copy, matching on
-signed amount and a small date window. A manual link carried only by the API
-copy is repointed to the surviving file op so no user intent is lost.
+collapsed here by keeping the API op (cleaner description and source_ref) and
+deleting the file copy, matching on signed amount and a small date window. The
+API op adopts the file's category, and the file copy's link is repointed to the
+surviving API op so the forecast keeps its actual attributions and no user
+intent is lost.
 """
 
 import logging
@@ -14,9 +16,12 @@ from datetime import date
 from functools import partial
 from typing import NamedTuple
 
+from budget_forecaster.core.types import Category
 from budget_forecaster.domain.operation import cross_source
 
 logger = logging.getLogger(__name__)
+
+_UNCATEGORIZED = Category.UNCATEGORIZED.value
 
 
 class _Op(NamedTuple):
@@ -25,18 +30,23 @@ class _Op(NamedTuple):
     unique_id: int
     op_date: date
     amount_cents: int
+    category: str
 
 
 def run(conn: sqlite3.Connection) -> None:
     """Collapse cross-source duplicate operations across every account."""
     purged = 0
     for (account_id,) in conn.execute("SELECT id FROM accounts").fetchall():
-        for api_id, file_id in _pairs_for_account(conn, account_id):
-            _reassign_manual_link(conn, from_op=api_id, to_op=file_id)
+        for api_op, file_op in _pairs_for_account(conn, account_id):
+            if file_op.category != _UNCATEGORIZED:
+                conn.execute(
+                    "UPDATE operations SET category = ? WHERE unique_id = ?",
+                    (file_op.category, api_op.unique_id),
+                )
+            _move_link(conn, from_op=file_op.unique_id, to_op=api_op.unique_id)
             conn.execute(
-                "DELETE FROM operation_links WHERE operation_unique_id = ?", (api_id,)
+                "DELETE FROM operations WHERE unique_id = ?", (file_op.unique_id,)
             )
-            conn.execute("DELETE FROM operations WHERE unique_id = ?", (api_id,))
             purged += 1
     conn.commit()
     logger.info("Purged %d cross-source duplicate operations", purged)
@@ -44,18 +54,18 @@ def run(conn: sqlite3.Connection) -> None:
 
 def _pairs_for_account(
     conn: sqlite3.Connection, account_id: int
-) -> tuple[tuple[int, int], ...]:
-    """Greedily pair each API op with a file op of matching amount and date.
+) -> tuple[tuple[_Op, _Op], ...]:
+    """Greedily pair each API op with the nearest matching file op.
 
-    Returns (api_unique_id, file_unique_id) pairs; matching is one-to-one so
-    distinct transactions sharing an amount and date are never collapsed. The
-    nearest date wins, mirroring the ingest-time reconciliation.
+    Returns (api_op, file_op) pairs; matching is one-to-one so distinct
+    transactions sharing an amount and date are never collapsed. The nearest
+    date wins, mirroring the ingest-time reconciliation.
     """
     file_ops = _load_ops(conn, account_id, with_source_ref=False)
     api_ops = _load_ops(conn, account_id, with_source_ref=True)
 
     matched_files: set[int] = set()
-    pairs: list[tuple[int, int]] = []
+    pairs: list[tuple[_Op, _Op]] = []
     for api in api_ops:
         candidates = [
             file_op
@@ -69,7 +79,7 @@ def _pairs_for_account(
             continue
         best = min(candidates, key=partial(_match_key, api.op_date))
         matched_files.add(best.unique_id)
-        pairs.append((api.unique_id, best.unique_id))
+        pairs.append((api, best))
     return tuple(pairs)
 
 
@@ -84,7 +94,7 @@ def _load_ops(
     """Load the file ops (no source_ref) or API ops (with source_ref)."""
     predicate = "IS NOT NULL" if with_source_ref else "IS NULL"
     cursor = conn.execute(
-        f"SELECT unique_id, date, amount FROM operations "  # noqa: S608
+        f"SELECT unique_id, date, amount, category FROM operations "  # noqa: S608
         f"WHERE account_id = ? AND source_ref {predicate} "
         f"ORDER BY date, unique_id",
         (account_id,),
@@ -94,26 +104,31 @@ def _load_ops(
             unique_id=row["unique_id"],
             op_date=date.fromisoformat(row["date"]),
             amount_cents=cross_source.amount_cents(row["amount"]),
+            category=row["category"],
         )
         for row in cursor.fetchall()
     )
 
 
-def _reassign_manual_link(conn: sqlite3.Connection, from_op: int, to_op: int) -> None:
-    """Move a manual link off the doomed op onto the survivor.
+def _move_link(conn: sqlite3.Connection, from_op: int, to_op: int) -> None:
+    """Move the doomed op's link onto the survivor.
 
-    Skips when the doomed op has no manual link. A manual link on the survivor
-    wins and is kept; an automatic one is overwritten, since manual intent
-    outranks a categorizer-derived link.
+    Both operations describe the same transaction, so the link stays valid. A
+    manual link already on the survivor wins and is kept; otherwise the doomed
+    op's link overwrites whatever the survivor had.
     """
-    if not _has_manual_link(conn, from_op):
+    if not _has_link(conn, from_op):
         return
     if _has_manual_link(conn, to_op):
-        logger.warning(
-            "Discarding manual link on op %d: survivor op %d is already "
-            "manually linked",
-            from_op,
-            to_op,
+        if _has_manual_link(conn, from_op):
+            logger.warning(
+                "Discarding manual link on op %d: survivor op %d is already "
+                "manually linked",
+                from_op,
+                to_op,
+            )
+        conn.execute(
+            "DELETE FROM operation_links WHERE operation_unique_id = ?", (from_op,)
         )
         return
     conn.execute("DELETE FROM operation_links WHERE operation_unique_id = ?", (to_op,))
@@ -122,6 +137,14 @@ def _reassign_manual_link(conn: sqlite3.Connection, from_op: int, to_op: int) ->
         "WHERE operation_unique_id = ?",
         (to_op, from_op),
     )
+
+
+def _has_link(conn: sqlite3.Connection, operation_id: int) -> bool:
+    """Whether the operation carries any link."""
+    row = conn.execute(
+        "SELECT 1 FROM operation_links WHERE operation_unique_id = ?", (operation_id,)
+    ).fetchone()
+    return row is not None
 
 
 def _has_manual_link(conn: sqlite3.Connection, operation_id: int) -> bool:

--- a/budget_forecaster/infrastructure/persistence/persistent_account.py
+++ b/budget_forecaster/infrastructure/persistence/persistent_account.py
@@ -1,8 +1,13 @@
 """Module for the PersistentAccount class."""
 
+import logging
+
 from budget_forecaster.core.types import ImportStats
 from budget_forecaster.domain.account.account import Account, AccountParameters
-from budget_forecaster.domain.account.aggregated_account import AggregatedAccount
+from budget_forecaster.domain.account.aggregated_account import (
+    AggregatedAccount,
+    Reconciliation,
+)
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
 from budget_forecaster.exceptions import AccountNotLoadedError
 from budget_forecaster.infrastructure.persistence.repository_interface import (
@@ -11,6 +16,8 @@ from budget_forecaster.infrastructure.persistence.repository_interface import (
 from budget_forecaster.services.operation.historic_operation_factory import (
     HistoricOperationFactory,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PersistentAccount:
@@ -78,10 +85,44 @@ class PersistentAccount:
     def upsert_account(self, account: AccountParameters) -> ImportStats:
         """Add or update an account.
 
+        Moves the link off each file op collapsed into an API op onto the
+        surviving API op, so a cross-source reconciliation keeps the forecast's
+        actual attributions and never loses a user-set link.
+
         Returns:
             ImportStats with the number of new and duplicate operations.
         """
-        return self._aggregated_account.upsert_account(account)
+        result = self._aggregated_account.upsert_account(account)
+        for reconciliation in result.reconciliations:
+            self._move_link(reconciliation)
+        return result.stats
+
+    def _move_link(self, reconciliation: Reconciliation) -> None:
+        """Move the dropped op's link onto the surviving API op.
+
+        Both ops describe the same transaction, so the link stays valid. A
+        manual link already on the survivor wins; otherwise the dropped op's
+        link overwrites whatever the survivor had.
+        """
+        if (
+            link := self._repository.get_link_for_operation(reconciliation.dropped_id)
+        ) is None:
+            return
+        survivor = self._repository.get_link_for_operation(reconciliation.kept_id)
+        if survivor is not None and survivor.is_manual:
+            if link.is_manual:
+                logger.warning(
+                    "Discarding manual link on op %d: survivor op %d is already "
+                    "manually linked",
+                    reconciliation.dropped_id,
+                    reconciliation.kept_id,
+                )
+            self._repository.delete_link(reconciliation.dropped_id)
+            return
+        self._repository.delete_link(reconciliation.dropped_id)
+        self._repository.upsert_link(
+            link._replace(operation_unique_id=reconciliation.kept_id, link_id=None)
+        )
 
     def replace_account(self, new_account: Account) -> None:
         """Replace an existing account."""

--- a/budget_forecaster/infrastructure/persistence/persistent_account.py
+++ b/budget_forecaster/infrastructure/persistence/persistent_account.py
@@ -38,6 +38,7 @@ class PersistentAccount:
         """
         self._repository = repository
         self._aggregated_account = self._load()
+        self._pending_reconciliations: tuple[Reconciliation, ...] = ()
 
     def _load(self) -> AggregatedAccount:
         """Load accounts from the repository.
@@ -63,10 +64,17 @@ class PersistentAccount:
         return HistoricOperationFactory(last_id)
 
     def save(self) -> None:
-        """Save the accounts to the repository."""
+        """Save the accounts, then move links for any cross-source reconciliation.
+
+        Links are moved only after the operations are persisted, so a failed
+        save leaves the stored links untouched rather than orphaning them.
+        """
         self._repository.set_aggregated_account_name(self.account.name)
         for acc in self.accounts:
             self._repository.upsert_account(acc)
+        for reconciliation in self._pending_reconciliations:
+            self._move_link(reconciliation)
+        self._pending_reconciliations = ()
 
     def reload(self) -> None:
         """Reload the accounts from the repository."""
@@ -85,16 +93,15 @@ class PersistentAccount:
     def upsert_account(self, account: AccountParameters) -> ImportStats:
         """Add or update an account.
 
-        Moves the link off each file op collapsed into an API op onto the
-        surviving API op, so a cross-source reconciliation keeps the forecast's
-        actual attributions and never loses a user-set link.
+        Records the cross-source pairs collapsed during the upsert; their links
+        are moved onto the surviving API op by the next save, once the ops are
+        persisted.
 
         Returns:
             ImportStats with the number of new and duplicate operations.
         """
         result = self._aggregated_account.upsert_account(account)
-        for reconciliation in result.reconciliations:
-            self._move_link(reconciliation)
+        self._pending_reconciliations += result.reconciliations
         return result.stats
 
     def _move_link(self, reconciliation: Reconciliation) -> None:

--- a/docs/dev/account.md
+++ b/docs/dev/account.md
@@ -122,9 +122,11 @@ sequenceDiagram
 BankAdapter auto-detects the file format (BNP Excel or Swile JSON). Operations are
 deduplicated against existing data before saving.
 
-Deduplication uses a two-level key. An operation with an external reference (the API
-entry_reference, absent for file imports) is a duplicate when that reference is already
-known, which makes repeated API syncs idempotent. Every operation also matches on a
-content ref (a stable hash of description, amount and day), so an API operation is
-reconciled against an overlapping file-imported one. Two same-day operations with
-distinct references are both kept.
+An operation with an external reference (the API entry_reference, absent for file
+imports) is a duplicate when that reference is already known, which makes repeated API
+syncs idempotent. An operation also matches on a content ref (a stable hash of
+description, amount and day). Because the same transaction gets a different description
+from a file export and from the API, a final fallback reconciles a file operation and an
+API operation by signed amount and a date within a few days. That cross-source match is
+one-to-one, so two same-day operations from the same source with distinct references are
+both kept.

--- a/docs/dev/account.md
+++ b/docs/dev/account.md
@@ -129,4 +129,5 @@ description, amount and day). Because the same transaction gets a different desc
 from a file export and from the API, a final fallback reconciles a file operation and an
 API operation by signed amount and a date within a few days. That cross-source match is
 one-to-one, so two same-day operations from the same source with distinct references are
-both kept.
+both kept. On a match, the API operation is kept and the file operation dropped; the
+survivor adopts the file's category and inherits its link.

--- a/docs/dev/persistence.md
+++ b/docs/dev/persistence.md
@@ -144,9 +144,13 @@ only amount and date line up. Cross-source matching is one-to-one and fires only
 a file operation and an API operation, so two same-source operations sharing an amount
 and date stay distinct (two identical same-day API operations are both kept).
 
-Version 10 purges cross-source duplicates already stored in existing databases, keeping
-the file operation and dropping the API copy; a manual link carried only by the API copy
-moves to the survivor.
+When a file operation and an API operation reconcile, the API operation is kept (cleaner
+description and stable reference) and the file operation is dropped. The API source
+carries no category, so the surviving operation adopts the file's category; the file
+operation's link moves to the survivor, keeping the forecast's actual attributions
+without waiting for a link recompute.
+
+Version 10 applies the same collapse to duplicates already stored in existing databases.
 
 ## Service Layer
 

--- a/docs/dev/persistence.md
+++ b/docs/dev/persistence.md
@@ -131,14 +131,22 @@ An operation carries a `source_ref` when its source provides a stable reference:
 - File imports (BNP, Swile) leave it NULL; a content reference (a hash of date, amount
   and description) is derived on the fly instead.
 
-An incoming operation is a duplicate when either:
+An incoming operation is a duplicate when any of these hold:
 
 - it has a reference and that reference is already stored for the account, or
-- it has no reference and its content reference matches a stored reference-less
-  operation.
+- its content reference matches a stored operation, or
+- it reconciles with a cross-source operation by signed amount and a date within a few
+  days.
 
-Two identical same-day API operations are both kept (distinct references); the content
-hash only collapses duplicates between file imports.
+The last rule handles the real cross-source case: the same transaction gets a different
+description from a file export and from the API, so the content references differ and
+only amount and date line up. Cross-source matching is one-to-one and fires only between
+a file operation and an API operation, so two same-source operations sharing an amount
+and date stay distinct (two identical same-day API operations are both kept).
+
+Version 10 purges cross-source duplicates already stored in existing databases, keeping
+the file operation and dropping the API copy; a manual link carried only by the API copy
+moves to the survivor.
 
 ## Service Layer
 

--- a/tests/domain/account/test_aggregated_account.py
+++ b/tests/domain/account/test_aggregated_account.py
@@ -260,9 +260,8 @@ class TestDedupWithSourceRef:
         assert result.stats.duplicates_skipped == 1
         assert len(result.account.operations) == 1
 
-    def test_file_op_incoming_after_api_op_is_not_reconciled(self) -> None:
-        """Accepted limitation: an incoming file op is not matched against an
-        existing API op, so re-importing a statement after API sync duplicates."""
+    def test_file_op_incoming_after_api_op_is_reconciled(self) -> None:
+        """An incoming file op reconciles against an existing API op."""
         api_op = _make_operation(
             1, "MONOPRIX", -12.5, date(2025, 1, 10), source_ref="ref-1"
         )
@@ -272,8 +271,114 @@ class TestDedupWithSourceRef:
 
         result = AggregatedAccount.update_account(current, self._params((file_op,)))
 
+        assert result.stats.duplicates_skipped == 1
+        assert len(result.account.operations) == 1
+
+
+class TestCrossSourceReconciliation:
+    """Reconcile a file op and an API op that share amount and date but not
+    description (the real cross-source duplicate case)."""
+
+    @staticmethod
+    def _params(operations: tuple[HistoricOperation, ...]) -> AccountParameters:
+        return AccountParameters(
+            name="BNP",
+            balance=None,
+            currency="EUR",
+            balance_date=date(2025, 1, 15),
+            operations=operations,
+        )
+
+    def test_api_op_reconciles_file_op_despite_different_wording(self) -> None:
+        """Incoming API op collapses onto a stored file op of the same amount."""
+        file_op = _make_operation(1, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10))
+        current = _make_account(operations=(file_op,))
+
+        api_op = _make_operation(
+            2, "VIR SEPA RECU /DE ELUM", 3574.0, date(2025, 1, 12), source_ref="ref-1"
+        )
+
+        result = AggregatedAccount.update_account(current, self._params((api_op,)))
+
+        assert result.stats.duplicates_skipped == 1
+        assert result.account.operations == (file_op,)
+
+    def test_file_op_reconciles_api_op_despite_different_wording(self) -> None:
+        """The reverse order deduplicates just as well."""
+        api_op = _make_operation(
+            1, "VIR SEPA RECU /DE ELUM", 3574.0, date(2025, 1, 12), source_ref="ref-1"
+        )
+        current = _make_account(operations=(api_op,))
+
+        file_op = _make_operation(2, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10))
+
+        result = AggregatedAccount.update_account(current, self._params((file_op,)))
+
+        assert result.stats.duplicates_skipped == 1
+        assert result.account.operations == (api_op,)
+
+    @pytest.mark.parametrize(
+        "api_date,expected_skipped",
+        [
+            (date(2025, 1, 13), 1),  # +3 days, inside window
+            (date(2025, 1, 7), 1),  # -3 days, inside window
+            (date(2025, 1, 14), 0),  # +4 days, outside window
+        ],
+        ids=["plus-3", "minus-3", "plus-4"],
+    )
+    def test_date_window_boundary(self, api_date: date, expected_skipped: int) -> None:
+        """The pair matches within a 3-day window and not beyond it."""
+        file_op = _make_operation(1, "PAYROLL", 3574.0, date(2025, 1, 10))
+        current = _make_account(operations=(file_op,))
+
+        api_op = _make_operation(2, "SALARY", 3574.0, api_date, source_ref="ref-1")
+
+        result = AggregatedAccount.update_account(current, self._params((api_op,)))
+
+        assert result.stats.duplicates_skipped == expected_skipped
+
+    def test_amount_must_match(self) -> None:
+        """A different amount is a distinct transaction, not a duplicate."""
+        file_op = _make_operation(1, "PAYROLL", 3574.0, date(2025, 1, 10))
+        current = _make_account(operations=(file_op,))
+
+        api_op = _make_operation(2, "SALARY", 3575.0, date(2025, 1, 10), source_ref="r")
+
+        result = AggregatedAccount.update_account(current, self._params((api_op,)))
+
         assert result.stats.new_operations == 1
         assert len(result.account.operations) == 2
+
+    def test_matching_is_one_to_one(self) -> None:
+        """One API op absorbs a single file op; a second same-amount file op stays."""
+        file_a = _make_operation(1, "COFFEE", -3.5, date(2025, 1, 10))
+        file_b = _make_operation(2, "COFFEE", -3.5, date(2025, 1, 10))
+        current = _make_account(operations=(file_a, file_b))
+
+        api_op = _make_operation(
+            3, "CB COFFEE", -3.5, date(2025, 1, 10), source_ref="r"
+        )
+
+        result = AggregatedAccount.update_account(current, self._params((api_op,)))
+
+        assert result.stats.duplicates_skipped == 1
+        assert len(result.account.operations) == 2
+
+    def test_re_sync_is_idempotent(self) -> None:
+        """Re-syncing the same API op after reconciliation adds nothing."""
+        file_op = _make_operation(1, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10))
+        current = _make_account(operations=(file_op,))
+        api_op = _make_operation(
+            2, "VIR SEPA RECU /DE ELUM", 3574.0, date(2025, 1, 12), source_ref="ref-1"
+        )
+
+        first = AggregatedAccount.update_account(current, self._params((api_op,)))
+        second = AggregatedAccount.update_account(
+            first.account, self._params((api_op,))
+        )
+
+        assert second.stats.duplicates_skipped == 1
+        assert len(second.account.operations) == 1
 
 
 class TestUpsertAccount:

--- a/tests/domain/account/test_aggregated_account.py
+++ b/tests/domain/account/test_aggregated_account.py
@@ -7,7 +7,10 @@ import pytest
 from budget_forecaster.core.amount import Amount
 from budget_forecaster.core.types import Category, ImportStats
 from budget_forecaster.domain.account.account import Account, AccountParameters
-from budget_forecaster.domain.account.aggregated_account import AggregatedAccount
+from budget_forecaster.domain.account.aggregated_account import (
+    AggregatedAccount,
+    Reconciliation,
+)
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
 
 
@@ -290,7 +293,7 @@ class TestCrossSourceReconciliation:
         )
 
     def test_api_op_reconciles_file_op_despite_different_wording(self) -> None:
-        """Incoming API op collapses onto a stored file op of the same amount."""
+        """Incoming API op collapses a stored file op, keeping the API record."""
         file_op = _make_operation(1, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10))
         current = _make_account(operations=(file_op,))
 
@@ -301,7 +304,8 @@ class TestCrossSourceReconciliation:
         result = AggregatedAccount.update_account(current, self._params((api_op,)))
 
         assert result.stats.duplicates_skipped == 1
-        assert result.account.operations == (file_op,)
+        assert result.account.operations == (api_op,)
+        assert result.reconciliations == (Reconciliation(dropped_id=1, kept_id=2),)
 
     def test_file_op_reconciles_api_op_despite_different_wording(self) -> None:
         """The reverse order deduplicates just as well."""
@@ -316,6 +320,7 @@ class TestCrossSourceReconciliation:
 
         assert result.stats.duplicates_skipped == 1
         assert result.account.operations == (api_op,)
+        assert result.reconciliations == (Reconciliation(dropped_id=2, kept_id=1),)
 
     @pytest.mark.parametrize(
         "api_date,expected_skipped",
@@ -401,6 +406,41 @@ class TestCrossSourceReconciliation:
         assert result.stats.new_operations == 0
         assert len(result.account.operations) == 2
 
+    def test_kept_api_op_inherits_file_category(self) -> None:
+        """The surviving API op adopts the categorized file op's category."""
+        file_op = _make_operation(
+            1, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10), category=Category.SALARY
+        )
+        current = _make_account(operations=(file_op,))
+
+        api_op = _make_operation(
+            2, "VIR SEPA RECU /DE ELUM", 3574.0, date(2025, 1, 12), source_ref="ref-1"
+        )
+
+        result = AggregatedAccount.update_account(current, self._params((api_op,)))
+
+        (survivor,) = result.account.operations
+        assert survivor.unique_id == 2
+        assert survivor.description == "VIR SEPA RECU /DE ELUM"
+        assert survivor.category == Category.SALARY
+
+    def test_existing_api_op_adopts_incoming_file_category(self) -> None:
+        """When the API op is stored and uncategorized, it adopts the file's."""
+        api_op = _make_operation(
+            1, "VIR SEPA RECU /DE ELUM", 3574.0, date(2025, 1, 12), source_ref="ref-1"
+        )
+        current = _make_account(operations=(api_op,))
+
+        file_op = _make_operation(
+            2, "VIREMENT DE ELUM", 3574.0, date(2025, 1, 10), category=Category.SALARY
+        )
+
+        result = AggregatedAccount.update_account(current, self._params((file_op,)))
+
+        (survivor,) = result.account.operations
+        assert survivor.unique_id == 1
+        assert survivor.category == Category.SALARY
+
 
 class TestUpsertAccount:
     """Tests for AggregatedAccount.upsert_account."""
@@ -420,7 +460,7 @@ class TestUpsertAccount:
             operations=(new_op,),
         )
 
-        stats = agg.upsert_account(new_params)
+        stats = agg.upsert_account(new_params).stats
 
         assert stats == ImportStats(
             total_in_file=1, new_operations=1, duplicates_skipped=0
@@ -446,7 +486,7 @@ class TestUpsertAccount:
             operations=(same_ref_other_account,),
         )
 
-        stats = agg.upsert_account(params)
+        stats = agg.upsert_account(params).stats
 
         assert stats == ImportStats(
             total_in_file=1, new_operations=1, duplicates_skipped=0
@@ -467,7 +507,7 @@ class TestUpsertAccount:
             operations=(new_op,),
         )
 
-        stats = agg.upsert_account(new_params)
+        stats = agg.upsert_account(new_params).stats
 
         assert stats == ImportStats(
             total_in_file=1, new_operations=1, duplicates_skipped=0
@@ -496,7 +536,7 @@ class TestUpsertAccount:
             operations=(new_op,),
         )
 
-        stats = agg.upsert_account(new_params)
+        stats = agg.upsert_account(new_params).stats
 
         assert stats == ImportStats(
             total_in_file=1, new_operations=1, duplicates_skipped=0
@@ -523,7 +563,7 @@ class TestUpsertAccount:
             balance_date=date(2025, 1, 10),
             operations=(op1,),
         )
-        stats1 = agg.upsert_account(params1)
+        stats1 = agg.upsert_account(params1).stats
         assert stats1 == ImportStats(
             total_in_file=1, new_operations=1, duplicates_skipped=0
         )
@@ -538,7 +578,7 @@ class TestUpsertAccount:
             balance_date=date(2025, 1, 15),
             operations=(op1, op2),
         )
-        stats2 = agg.upsert_account(params2)
+        stats2 = agg.upsert_account(params2).stats
         assert stats2 == ImportStats(
             total_in_file=2, new_operations=1, duplicates_skipped=1
         )

--- a/tests/domain/account/test_aggregated_account.py
+++ b/tests/domain/account/test_aggregated_account.py
@@ -380,6 +380,27 @@ class TestCrossSourceReconciliation:
         assert second.stats.duplicates_skipped == 1
         assert len(second.account.operations) == 1
 
+    def test_nearest_existing_candidate_is_reconciled(self) -> None:
+        """The nearest existing op is paired, freeing the far one for a later op.
+
+        Two file ops one day apart. The first incoming op matches both; pairing
+        it with the nearest keeps the far file op available for the second
+        incoming, which would otherwise fall outside the window and duplicate.
+        """
+        file_1 = _make_operation(1, "COFFEE", -3.5, date(2025, 1, 10))
+        file_2 = _make_operation(2, "COFFEE", -3.5, date(2025, 1, 11))
+        current = _make_account(operations=(file_1, file_2))
+
+        api_near = _make_operation(3, "CB", -3.5, date(2025, 1, 11), source_ref="a")
+        api_far = _make_operation(4, "CB", -3.5, date(2025, 1, 7), source_ref="b")
+
+        result = AggregatedAccount.update_account(
+            current, self._params((api_near, api_far))
+        )
+
+        assert result.stats.new_operations == 0
+        assert len(result.account.operations) == 2
+
 
 class TestUpsertAccount:
     """Tests for AggregatedAccount.upsert_account."""

--- a/tests/infrastructure/persistence/test_persistent_account.py
+++ b/tests/infrastructure/persistence/test_persistent_account.py
@@ -15,10 +15,11 @@ from budget_forecaster.core.date_range import (
     RecurringDay,
     SingleDay,
 )
-from budget_forecaster.core.types import Category
+from budget_forecaster.core.types import Category, LinkType
 from budget_forecaster.domain.account.account import Account, AccountParameters
 from budget_forecaster.domain.operation.budget import Budget
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
+from budget_forecaster.domain.operation.operation_link import OperationLink
 from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.exceptions import (
     AccountNotFoundError,
@@ -367,6 +368,67 @@ class TestPersistentAccount:
 
             account = persistent2.accounts[0]
             assert len(account.operations) == 4
+
+    def test_manual_link_follows_cross_source_reconciliation(
+        self, temp_db_path: Path
+    ) -> None:
+        """A manual link on a file op moves to the API op that replaces it."""
+        file_op = HistoricOperation(
+            unique_id=1,
+            description="VIREMENT DE ELUM",
+            amount=Amount(3574.0, "EUR"),
+            category=Category.SALARY,
+            operation_date=date(2025, 1, 10),
+        )
+        account = Account(
+            name="BNP",
+            balance=3574.0,
+            currency="EUR",
+            balance_date=date(2025, 1, 10),
+            operations=(file_op,),
+        )
+        with SqliteRepository(temp_db_path) as repository:
+            repository.set_aggregated_account_name("All")
+            repository.upsert_account(account)
+            repository.upsert_link(
+                OperationLink(
+                    operation_unique_id=1,
+                    target_type=LinkType.PLANNED_OPERATION,
+                    target_id=7,
+                    iteration_date=date(2025, 1, 10),
+                    is_manual=True,
+                )
+            )
+
+        with SqliteRepository(temp_db_path) as repository:
+            persistent = PersistentAccount(repository)
+            api_op = HistoricOperation(
+                unique_id=2,
+                description="VIR SEPA RECU /DE ELUM",
+                amount=Amount(3574.0, "EUR"),
+                category=Category.UNCATEGORIZED,
+                operation_date=date(2025, 1, 12),
+                source_ref="ref-1",
+            )
+            params = AccountParameters(
+                name="BNP",
+                balance=3574.0,
+                currency="EUR",
+                balance_date=date(2025, 1, 12),
+                operations=(api_op,),
+            )
+            persistent.upsert_account(params)
+            persistent.save()
+
+        with SqliteRepository(temp_db_path) as repository:
+            persistent = PersistentAccount(repository)
+            operations = persistent.accounts[0].operations
+            assert {op.unique_id for op in operations} == {2}
+            assert repository.get_link_for_operation(1) is None
+            link = repository.get_link_for_operation(2)
+            assert link is not None
+            assert link.is_manual
+            assert link.target_id == 7
 
 
 class TestBudgetRepository:

--- a/tests/infrastructure/persistence/test_purge_cross_source_migration.py
+++ b/tests/infrastructure/persistence/test_purge_cross_source_migration.py
@@ -129,3 +129,48 @@ def test_automatic_link_is_not_repointed(conn: sqlite3.Connection) -> None:
     v010.run(conn)
 
     assert conn.execute("SELECT COUNT(*) FROM operation_links").fetchone()[0] == 0
+
+
+def test_manual_link_wins_over_survivor_automatic_link(
+    conn: sqlite3.Connection,
+) -> None:
+    """A manual link on the API op overwrites an automatic link on the survivor."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, auto link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
+    conn.executemany(
+        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
+        "iteration_date, is_manual) VALUES (?, 'budget', ?, '2025-01-12', ?)",
+        [(1, 5, 0), (2, 9, 1)],
+    )
+
+    v010.run(conn)
+
+    rows = conn.execute(
+        "SELECT operation_unique_id, target_id, is_manual FROM operation_links"
+    ).fetchall()
+    assert [
+        (r["operation_unique_id"], r["target_id"], r["is_manual"]) for r in rows
+    ] == [(1, 9, 1)]
+
+
+def test_migration_is_idempotent(conn: sqlite3.Connection) -> None:
+    """Running the purge twice leaves the same rows the second time."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")
+
+    v010.run(conn)
+    v010.run(conn)
+
+    assert _op_ids(conn) == {1}
+
+
+def test_multiple_pairs_matched_by_nearest_date(conn: sqlite3.Connection) -> None:
+    """Each API op pairs with the nearest file op, so none is stranded."""
+    _insert_op(conn, 1, "2025-01-10", -3.5, source_ref=None)
+    _insert_op(conn, 2, "2025-01-11", -3.5, source_ref=None)
+    _insert_op(conn, 3, "2025-01-11", -3.5, source_ref="ref-a")  # nearest to op 2
+    _insert_op(conn, 4, "2025-01-07", -3.5, source_ref="ref-b")  # falls back to op 1
+
+    v010.run(conn)
+
+    assert _op_ids(conn) == {1, 2}

--- a/tests/infrastructure/persistence/test_purge_cross_source_migration.py
+++ b/tests/infrastructure/persistence/test_purge_cross_source_migration.py
@@ -1,0 +1,131 @@
+"""Tests for the v10 cross-source duplicate purge migration."""
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from budget_forecaster.infrastructure.persistence.migrations import (
+    v010_purge_cross_source_duplicates as v010,
+)
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+
+
+@pytest.fixture(name="conn")
+def conn_fixture(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    """An initialized database seeded with one aggregated account."""
+    with SqliteRepository(tmp_path / "test.db") as repo:
+        conn = repo._get_connection()  # pylint: disable=protected-access
+        conn.execute("INSERT INTO aggregated_accounts (id, name) VALUES (1, 'All')")
+        conn.execute(
+            "INSERT INTO accounts (id, aggregated_account_id, name, balance, "
+            "currency, balance_date) VALUES (1, 1, 'BNP', 100.0, 'EUR', '2025-01-31')"
+        )
+        yield conn
+
+
+def _insert_op(
+    conn: sqlite3.Connection,
+    unique_id: int,
+    op_date: str,
+    amount: float,
+    source_ref: str | None,
+) -> None:
+    conn.execute(
+        "INSERT INTO operations (unique_id, account_id, description, category, "
+        "date, amount, currency, source_ref) "
+        "VALUES (?, 1, 'op', 'uncategorized', ?, ?, 'EUR', ?)",
+        (unique_id, op_date, amount, source_ref),
+    )
+
+
+def _op_ids(conn: sqlite3.Connection) -> set[int]:
+    return {
+        row["unique_id"] for row in conn.execute("SELECT unique_id FROM operations")
+    }
+
+
+def test_cross_source_pair_is_collapsed(conn: sqlite3.Connection) -> None:
+    """The API copy is deleted and the file op survives."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API dup
+
+    v010.run(conn)
+
+    assert _op_ids(conn) == {1}
+
+
+def test_distinct_ops_are_kept(conn: sqlite3.Connection) -> None:
+    """Ops outside the window or of a different amount are left alone."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)
+    _insert_op(conn, 2, "2025-01-20", 3574.0, source_ref="ref-1")  # too far
+    _insert_op(conn, 3, "2025-01-10", 50.0, source_ref="ref-2")  # other amount
+
+    v010.run(conn)
+
+    assert _op_ids(conn) == {1, 2, 3}
+
+
+def test_matching_is_one_to_one(conn: sqlite3.Connection) -> None:
+    """A single API op collapses one of two same-amount file ops."""
+    _insert_op(conn, 1, "2025-01-10", -3.5, source_ref=None)
+    _insert_op(conn, 2, "2025-01-10", -3.5, source_ref=None)
+    _insert_op(conn, 3, "2025-01-10", -3.5, source_ref="ref-1")
+
+    v010.run(conn)
+
+    assert _op_ids(conn) == {1, 2}
+
+
+def test_manual_link_repointed_to_survivor(conn: sqlite3.Connection) -> None:
+    """A manual link on the deleted API op moves to the surviving file op."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, no link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
+    conn.execute(
+        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
+        "iteration_date, is_manual) VALUES (2, 'planned_operation', 7, '2025-01-12', 1)"
+    )
+
+    v010.run(conn)
+
+    rows = conn.execute(
+        "SELECT operation_unique_id, target_id FROM operation_links"
+    ).fetchall()
+    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(1, 7)]
+
+
+def test_manual_link_dropped_when_survivor_already_linked(
+    conn: sqlite3.Connection,
+) -> None:
+    """The survivor keeps its own link; the API op's link is discarded."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, manual link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
+    conn.executemany(
+        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
+        "iteration_date, is_manual) VALUES (?, 'budget', ?, '2025-01-12', 1)",
+        [(1, 5), (2, 9)],
+    )
+
+    v010.run(conn)
+
+    rows = conn.execute(
+        "SELECT operation_unique_id, target_id FROM operation_links"
+    ).fetchall()
+    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(1, 5)]
+
+
+def test_automatic_link_is_not_repointed(conn: sqlite3.Connection) -> None:
+    """An automatic link on the API op is dropped, not moved (categorizer rebuilds)."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")
+    conn.execute(
+        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
+        "iteration_date, is_manual) VALUES (2, 'budget', 3, '2025-01-12', 0)"
+    )
+
+    v010.run(conn)
+
+    assert conn.execute("SELECT COUNT(*) FROM operation_links").fetchone()[0] == 0

--- a/tests/infrastructure/persistence/test_purge_cross_source_migration.py
+++ b/tests/infrastructure/persistence/test_purge_cross_source_migration.py
@@ -33,12 +33,13 @@ def _insert_op(
     op_date: str,
     amount: float,
     source_ref: str | None,
+    category: str = "uncategorized",
 ) -> None:
     conn.execute(
         "INSERT INTO operations (unique_id, account_id, description, category, "
         "date, amount, currency, source_ref) "
-        "VALUES (?, 1, 'op', 'uncategorized', ?, ?, 'EUR', ?)",
-        (unique_id, op_date, amount, source_ref),
+        "VALUES (?, 1, 'op', ?, ?, ?, 'EUR', ?)",
+        (unique_id, category, op_date, amount, source_ref),
     )
 
 
@@ -48,14 +49,14 @@ def _op_ids(conn: sqlite3.Connection) -> set[int]:
     }
 
 
-def test_cross_source_pair_is_collapsed(conn: sqlite3.Connection) -> None:
-    """The API copy is deleted and the file op survives."""
+def test_cross_source_pair_keeps_api_op(conn: sqlite3.Connection) -> None:
+    """The file copy is deleted and the API op survives."""
     _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file
-    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API dup
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API kept
 
     v010.run(conn)
 
-    assert _op_ids(conn) == {1}
+    assert _op_ids(conn) == {2}
 
 
 def test_distinct_ops_are_kept(conn: sqlite3.Connection) -> None:
@@ -77,16 +78,51 @@ def test_matching_is_one_to_one(conn: sqlite3.Connection) -> None:
 
     v010.run(conn)
 
-    assert _op_ids(conn) == {1, 2}
+    # File op 1 (lowest id) pairs with the API op and is deleted; file op 2 stays.
+    assert _op_ids(conn) == {2, 3}
 
 
-def test_manual_link_repointed_to_survivor(conn: sqlite3.Connection) -> None:
-    """A manual link on the deleted API op moves to the surviving file op."""
-    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, no link
-    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
+def test_multiple_pairs_matched_by_nearest_date(conn: sqlite3.Connection) -> None:
+    """Each API op pairs with the nearest file op, so none is stranded."""
+    _insert_op(conn, 1, "2025-01-10", -3.5, source_ref=None)
+    _insert_op(conn, 2, "2025-01-11", -3.5, source_ref=None)
+    _insert_op(conn, 3, "2025-01-11", -3.5, source_ref="ref-a")  # nearest to op 2
+    _insert_op(conn, 4, "2025-01-07", -3.5, source_ref="ref-b")  # falls back to op 1
+
+    v010.run(conn)
+
+    assert _op_ids(conn) == {3, 4}
+
+
+def test_api_op_adopts_file_category(conn: sqlite3.Connection) -> None:
+    """The surviving API op inherits the categorized file op's category."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None, category="salary")
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # uncategorized
+
+    v010.run(conn)
+
+    row = conn.execute("SELECT category FROM operations WHERE unique_id = 2").fetchone()
+    assert row["category"] == "salary"
+
+
+def test_api_category_kept_when_file_uncategorized(conn: sqlite3.Connection) -> None:
+    """An uncategorized file op does not overwrite the API op's own category."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # uncategorized
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1", category="salary")
+
+    v010.run(conn)
+
+    row = conn.execute("SELECT category FROM operations WHERE unique_id = 2").fetchone()
+    assert row["category"] == "salary"
+
+
+def test_manual_link_repointed_to_api_survivor(conn: sqlite3.Connection) -> None:
+    """A manual link on the deleted file op moves to the surviving API op."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, manual link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, no link
     conn.execute(
         "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
-        "iteration_date, is_manual) VALUES (2, 'planned_operation', 7, '2025-01-12', 1)"
+        "iteration_date, is_manual) VALUES (1, 'planned_operation', 7, '2025-01-10', 1)"
     )
 
     v010.run(conn)
@@ -94,13 +130,13 @@ def test_manual_link_repointed_to_survivor(conn: sqlite3.Connection) -> None:
     rows = conn.execute(
         "SELECT operation_unique_id, target_id FROM operation_links"
     ).fetchall()
-    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(1, 7)]
+    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(2, 7)]
 
 
 def test_manual_link_dropped_when_survivor_already_linked(
     conn: sqlite3.Connection,
 ) -> None:
-    """The survivor keeps its own link; the API op's link is discarded."""
+    """The API survivor keeps its own manual link; the file's is discarded."""
     _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, manual link
     _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
     conn.executemany(
@@ -114,33 +150,19 @@ def test_manual_link_dropped_when_survivor_already_linked(
     rows = conn.execute(
         "SELECT operation_unique_id, target_id FROM operation_links"
     ).fetchall()
-    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(1, 5)]
-
-
-def test_automatic_link_is_not_repointed(conn: sqlite3.Connection) -> None:
-    """An automatic link on the API op is dropped, not moved (categorizer rebuilds)."""
-    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)
-    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")
-    conn.execute(
-        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
-        "iteration_date, is_manual) VALUES (2, 'budget', 3, '2025-01-12', 0)"
-    )
-
-    v010.run(conn)
-
-    assert conn.execute("SELECT COUNT(*) FROM operation_links").fetchone()[0] == 0
+    assert [(r["operation_unique_id"], r["target_id"]) for r in rows] == [(2, 9)]
 
 
 def test_manual_link_wins_over_survivor_automatic_link(
     conn: sqlite3.Connection,
 ) -> None:
-    """A manual link on the API op overwrites an automatic link on the survivor."""
-    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, auto link
-    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, manual link
+    """A manual link on the file op overwrites an automatic link on the API op."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, manual link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")  # API, auto link
     conn.executemany(
         "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
         "iteration_date, is_manual) VALUES (?, 'budget', ?, '2025-01-12', ?)",
-        [(1, 5, 0), (2, 9, 1)],
+        [(1, 9, 1), (2, 5, 0)],
     )
 
     v010.run(conn)
@@ -150,7 +172,26 @@ def test_manual_link_wins_over_survivor_automatic_link(
     ).fetchall()
     assert [
         (r["operation_unique_id"], r["target_id"], r["is_manual"]) for r in rows
-    ] == [(1, 9, 1)]
+    ] == [(2, 9, 1)]
+
+
+def test_automatic_link_on_file_op_is_moved_to_api(conn: sqlite3.Connection) -> None:
+    """An automatic link on the file op moves to the API op, keeping attribution."""
+    _insert_op(conn, 1, "2025-01-10", 3574.0, source_ref=None)  # file, auto link
+    _insert_op(conn, 2, "2025-01-12", 3574.0, source_ref="ref-1")
+    conn.execute(
+        "INSERT INTO operation_links (operation_unique_id, target_type, target_id, "
+        "iteration_date, is_manual) VALUES (1, 'budget', 3, '2025-01-10', 0)"
+    )
+
+    v010.run(conn)
+
+    rows = conn.execute(
+        "SELECT operation_unique_id, target_id, is_manual FROM operation_links"
+    ).fetchall()
+    assert [
+        (r["operation_unique_id"], r["target_id"], r["is_manual"]) for r in rows
+    ] == [(2, 3, 0)]
 
 
 def test_migration_is_idempotent(conn: sqlite3.Connection) -> None:
@@ -161,16 +202,4 @@ def test_migration_is_idempotent(conn: sqlite3.Connection) -> None:
     v010.run(conn)
     v010.run(conn)
 
-    assert _op_ids(conn) == {1}
-
-
-def test_multiple_pairs_matched_by_nearest_date(conn: sqlite3.Connection) -> None:
-    """Each API op pairs with the nearest file op, so none is stranded."""
-    _insert_op(conn, 1, "2025-01-10", -3.5, source_ref=None)
-    _insert_op(conn, 2, "2025-01-11", -3.5, source_ref=None)
-    _insert_op(conn, 3, "2025-01-11", -3.5, source_ref="ref-a")  # nearest to op 2
-    _insert_op(conn, 4, "2025-01-07", -3.5, source_ref="ref-b")  # falls back to op 1
-
-    v010.run(conn)
-
-    assert _op_ids(conn) == {1, 2}
+    assert _op_ids(conn) == {2}


### PR DESCRIPTION
## Context

When the same account is ingested from a file export (BNP xlsx) and from the Enable Banking API sync, the same real transaction was stored twice. Each source gives it a different description, so the content-ref dedup key (hash of description + amount + date) never matched across sources. Balances and category totals were inflated, and the balance-evolution chart showed a phantom overdraft.

## Fix

Reconcile a file op and an API op that describe the same transaction by signed amount and a date within a 3-day window, cross-source only (exactly one side carries a `source_ref`), one-to-one, nearest date wins.

On a match:

- Keep the **API op** (cleaner description and stable `source_ref`); drop the file copy, so historical data lines up with what future syncs produce.
- The surviving API op **adopts the file op's category** (the API source carries none; an uncategorized file leaves the API's own value).
- The file op's **link is repointed** to the survivor, so the forecast keeps its actual attributions without waiting for a link recompute; a manual link already on the survivor wins.

`update_account` / `upsert_account` surface the reconciled pairs; `PersistentAccount` moves the links after `save()` persists the operations. Incoming ops are processed in `(date, id)` order so ambiguous clusters resolve the same way as the migration.

**Migration v010** applies the same collapse to duplicates already stored: keep the API row, adopt the file category, move the file's link, delete the file row.

Shared amount/date matching primitives live in a single module so the ingest path and the migration can't drift.

## Verification (on a copy of a real database)

- 313 duplicate pairs collapsed (3384 → 3071 operations), net inflation of ~+3399 EUR removed.
- All 2107 operation links preserved, 0 orphaned.
- Surviving API ops inherit their category: 313/317 categorized (0 before).
- Balance-evolution start realistic at +280 EUR (was −3118 phantom); forecast min unchanged at +5.53 EUR.
- Confirmed end-to-end through the web app.

## Tests

- Both ingest orders (file→API, API→file) collapse to one op.
- Date-window boundary (±3 in, 4 out), amount must match, one-to-one, nearest-candidate selection, re-sync idempotency.
- Category inheritance both directions; link repointing (manual, automatic, manual-over-automatic, manual-clash); migration idempotency and multi-pair matching.

## Related issues

- Related to #289 (Enable Banking ingestion), #291 (source_ref dedup key), #298 (account identity)

Fixes #310
