### PR TITLE
feat: web app deployment (systemd + Tailscale + docs)

### DIFF
--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -1,6 +1,7 @@
 """Main module for the Budget Forecaster application."""
 
 import argparse
+import getpass
 import logging
 import sys
 from pathlib import Path
@@ -21,6 +22,7 @@ from budget_forecaster.infrastructure.bank_sources.enable_banking.sync_runner im
 from budget_forecaster.infrastructure.bootstrap import open_repository
 from budget_forecaster.infrastructure.config import Config, EnableBankingConfig
 from budget_forecaster.tui.app import run_app
+from budget_forecaster.web.auth import hash_password
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +101,23 @@ def _run_consent_status(config_path: Path) -> None:
     print(f"Consent {state.status.value}, valid until {state.valid_until.date()}.")
 
 
+def _run_hash_password() -> None:
+    """Prompt for a password and print its hash for the web app secret."""
+    try:
+        password = getpass.getpass("Password: ")
+        confirm = getpass.getpass("Confirm: ")
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.", file=sys.stderr)
+        sys.exit(1)
+    if password != confirm:
+        print("Passwords do not match.", file=sys.stderr)
+        sys.exit(1)
+    if not password:
+        print("Password must not be empty.", file=sys.stderr)
+        sys.exit(1)
+    print(hash_password(password))
+
+
 def main() -> None:
     """Entry point: launch the TUI, or run a subcommand such as sync."""
     default_config_path = Path("~/.config/budget-forecaster/config.yaml").expanduser()
@@ -118,7 +137,15 @@ def main() -> None:
     subparsers.add_parser(
         "consent-status", help="Show the Enable Banking consent status and expiry"
     )
+    subparsers.add_parser(
+        "hash-password", help="Hash a web app password for BUDGET_WEB_PASSWORD_HASH"
+    )
     args = parser.parse_args()
+
+    # Config-independent: no config file needed to hash a password.
+    if args.command == "hash-password":
+        _run_hash_password()
+        return
 
     config_path = args.config.expanduser()
 

--- a/deploy/service.env.example
+++ b/deploy/service.env.example
@@ -1,0 +1,23 @@
+# Budget Forecaster service environment (web app + sync).
+# Copy to ~/.config/budget-forecaster/service.env and fill in the secrets.
+# Keep this file private: chmod 600.
+# All variables below must be present: systemd does not apply defaults for a
+# missing one, so an empty ${BUDGET_WEB_PORT} would break the uvicorn command.
+
+# Path to the app config file (used by the web app and the sync service).
+# Must be an absolute path: env-file values are not shell- or %h-expanded.
+BUDGET_CONFIG=/home/YOUR_USER/.config/budget-forecaster/config.yaml
+
+# Cookie signing key. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+BUDGET_WEB_SECRET_KEY=
+
+# Shared password hash. Generate with:
+#   python -m budget_forecaster.main hash-password
+BUDGET_WEB_PASSWORD_HASH=
+
+# Set the Secure flag on cookies. On (HTTPS via Tailscale) in production.
+BUDGET_WEB_SECURE_COOKIES=1
+
+# Port uvicorn binds on 127.0.0.1. Tailscale serve forwards to it.
+BUDGET_WEB_PORT=8000

--- a/deploy/systemd/budget-sync.service
+++ b/deploy/systemd/budget-sync.service
@@ -1,0 +1,10 @@
+# User service: one bank sync, recorded as a sync_runs row. Driven by budget-sync.timer.
+# Edit ExecStart if your virtualenv lives elsewhere than ~/budget-forecaster-venv.
+# Reads service.env only for BUDGET_CONFIG (shared with budget-web.service).
+[Unit]
+Description=Budget Forecaster bank sync
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/budget-forecaster/service.env
+ExecStart=%h/budget-forecaster-venv/bin/python -m budget_forecaster.main -c ${BUDGET_CONFIG} sync

--- a/deploy/systemd/budget-sync.timer
+++ b/deploy/systemd/budget-sync.timer
@@ -1,0 +1,10 @@
+# Daily trigger for budget-sync.service. Persistent catches up a missed run after downtime.
+[Unit]
+Description=Daily Budget Forecaster bank sync
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/budget-web.service
+++ b/deploy/systemd/budget-web.service
@@ -1,0 +1,17 @@
+# User service: the Budget Forecaster web app.
+# Install: see docs/user/deployment.md
+# Edit ExecStart if your virtualenv lives elsewhere than ~/budget-forecaster-venv.
+# A --user manager has no network-online.target, so no network ordering here;
+# Restart=on-failure covers a start before the network is up.
+[Unit]
+Description=Budget Forecaster web app
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.config/budget-forecaster/service.env
+ExecStart=%h/budget-forecaster-venv/bin/uvicorn --factory budget_forecaster.web.app:create_app --host 127.0.0.1 --port ${BUDGET_WEB_PORT}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -1,0 +1,174 @@
+# Deployment
+
+How to run the [web app](web-app.md) as a background service, reachable from your phone
+and other PCs over your private Tailscale network, with the bank sync on a daily timer.
+
+The app binds to `127.0.0.1` only and is never exposed to the public internet: Tailscale
+is the sole entry point, and it terminates HTTPS with a valid certificate for your
+machine's `*.ts.net` name.
+
+Two hosts are supported, sharing the same units and steps:
+
+- A dedicated Linux machine (Raspberry Pi, mini-PC) — always on, nothing to mix with a
+  work laptop. Recommended.
+- Your own PC through WSL2 on Windows.
+
+Follow the [Common setup](#common-setup) first, then the
+[host prerequisites](#host-prerequisites) for your machine.
+
+## Common setup
+
+These steps are identical on any Linux host, including WSL2.
+
+### 1. Install the app
+
+Clone the repository, create a virtualenv, and install:
+
+```bash
+git clone https://github.com/corentin-core/budget-forecaster.git
+cd budget-forecaster
+python3 -m venv ~/budget-forecaster-venv
+~/budget-forecaster-venv/bin/pip install -e .
+```
+
+The systemd units expect the virtualenv at `~/budget-forecaster-venv`. If yours is
+elsewhere, edit `ExecStart` in both service files.
+
+Put your `config.yaml` and the account database where the service will find them, e.g.
+`~/.config/budget-forecaster/`.
+
+### 2. Secrets
+
+The app needs a cookie signing key and the shared-password hash. Generate both:
+
+```bash
+# Signing key
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+
+# Password hash (prompts for the password twice)
+python -m budget_forecaster.main hash-password
+```
+
+Copy the environment template and fill it in:
+
+```bash
+mkdir -p ~/.config/budget-forecaster
+cp deploy/service.env.example ~/.config/budget-forecaster/service.env
+chmod 600 ~/.config/budget-forecaster/service.env
+```
+
+Edit `service.env`: set `BUDGET_CONFIG` to the absolute path of your config file, paste
+the signing key into `BUDGET_WEB_SECRET_KEY` and the hash into
+`BUDGET_WEB_PASSWORD_HASH`, and keep `BUDGET_WEB_SECURE_COOKIES=1`. Keep all variables
+present — systemd applies no default for a missing one.
+
+### 3. Tailscale
+
+Install Tailscale and join your tailnet:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Then let Tailscale serve the app over HTTPS on your node's `*.ts.net` name:
+
+```bash
+sudo tailscale serve --bg http://127.0.0.1:8000
+```
+
+`tailscale serve` persists across reboots. Find your node name with `tailscale status`;
+the app is then reachable at `https://<node>.<tailnet>.ts.net`.
+
+### 4. systemd services
+
+Install the units as user services (no root; they run under your account):
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp deploy/systemd/budget-web.service deploy/systemd/budget-sync.service deploy/systemd/budget-sync.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now budget-web.service
+systemctl --user enable --now budget-sync.timer
+```
+
+Let the services keep running after you log out, and start on boot:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+Check status and logs:
+
+```bash
+systemctl --user status budget-web.service
+journalctl --user -u budget-web.service -f
+systemctl --user list-timers budget-sync.timer
+```
+
+### 5. Bank callback
+
+Register the callback URL in the Enable Banking portal so the OAuth redirect lands back
+in the app:
+
+```text
+https://<node>.<tailnet>.ts.net/settings/bank/callback
+```
+
+Set the same URL as `enable_banking.redirect_url` in your `config.yaml`, replacing the
+`localhost` value used during local development — the portal registration and the config
+must match, or the bank never redirects back. See the
+[Enable Banking guide](enable-banking.md) for the portal setup.
+
+### Access
+
+Install Tailscale on your phone and other PCs, sign in to the same tailnet, and open
+`https://<node>.<tailnet>.ts.net`. Sign in with the shared password. Nothing else needs
+installing on those devices.
+
+### Updating
+
+```bash
+cd budget-forecaster
+git pull
+~/budget-forecaster-venv/bin/pip install -e .
+systemctl --user restart budget-web.service
+```
+
+## Host prerequisites
+
+### Raspberry Pi / mini-PC (native Linux)
+
+Nothing extra. systemd is already the init system, user services start on boot once
+linger is enabled, and Tailscale runs natively. Follow the common setup as-is.
+
+### Windows via WSL2
+
+Install WSL2 with a recent Ubuntu, then:
+
+1. **Enable systemd** inside the distro. Add to `/etc/wsl.conf`:
+
+   ```ini
+   [boot]
+   systemd=true
+   ```
+
+   Then `wsl --shutdown` from Windows and reopen the distro.
+
+2. **Start WSL on Windows boot** so the services come up without you opening a terminal.
+   Create a Windows Task Scheduler task that runs at logon:
+
+   - Program: `wsl.exe`
+   - Arguments: `-d Ubuntu true`
+
+   This boots the distro (and its systemd services) in the background.
+
+3. **Tailscale TUN fallback.** If `sudo tailscale up` reports no TUN device, run it in
+   userspace-networking mode:
+
+   ```bash
+   sudo tailscaled --tun=userspace-networking &
+   sudo tailscale up
+   ```
+
+Then follow the common setup.

--- a/docs/user/web-app.md
+++ b/docs/user/web-app.md
@@ -4,8 +4,8 @@ A mobile-first web interface over the same budget database as the TUI. It shows 
 balance, monthly review, operations ledger, trends, and connection status, and lets you
 categorize operations, link them to budgets or planned operations, and manage budgets
 and planned operations. Every interaction stays on the page or opens a dedicated page —
-there are no blocking pop-up dialogs. Sync controls and remote access over Tailscale
-come in later versions.
+there are no blocking pop-up dialogs. To run it as a background service reachable from
+your phone and other PCs over Tailscale, see the [deployment guide](deployment.md).
 
 ## Running the app
 
@@ -35,10 +35,11 @@ configure on the phones and PCs that connect.
 The server needs two secrets: a signing key for the session cookie and the password
 hash.
 
-Generate the password hash once from your chosen password:
+Generate the password hash once (prompts for the password, keeps it off your shell
+history):
 
 ```bash
-python -c "from budget_forecaster.web.auth import hash_password; print(hash_password('your-password'))"
+python -m budget_forecaster.main hash-password
 ```
 
 Provide both secrets through the environment (recommended for a deployed server):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
       - TUI Monthly Review: user/tui-review.md
       - TUI Planned Operations & Budgets: user/tui-planned-budgets.md
       - Available Margin: user/available-margin.md
+      - Web App: user/web-app.md
+      - Deployment: user/deployment.md
   - Developer:
       - Architecture: dev/architecture.md
       - Operations: dev/operations.md

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from budget_forecaster.core.types import SyncRunStatus
 from budget_forecaster.infrastructure.persistence.sqlite_repository import (
     SqliteRepository,
 )
+from budget_forecaster.web.auth import verify_password
 
 
 def test_sync_without_enable_banking_exits(
@@ -75,3 +76,54 @@ def test_sync_records_failed_run_when_no_consent(
     with SqliteRepository(tmp_path / "x.db") as repo:
         (run,) = repo.get_recent_sync_runs(1)
     assert run.status is SyncRunStatus.FAILED
+
+
+def test_hash_password_prints_verifiable_hash(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """hash-password prints a verifiable hash and never touches the config file."""
+    config_file = tmp_path / "config.yaml"
+    monkeypatch.setattr(main.getpass, "getpass", lambda _prompt: "s3cret")
+    monkeypatch.setattr(
+        "sys.argv", ["budget-forecaster", "-c", str(config_file), "hash-password"]
+    )
+
+    main.main()
+
+    printed = capsys.readouterr().out.strip()
+    assert verify_password("s3cret", printed)
+    assert not verify_password("wrong", printed)
+    assert not config_file.exists()
+
+
+def test_hash_password_exits_on_mismatch(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """hash-password exits 1 when the confirmation does not match."""
+    answers = iter(["one", "two"])
+    monkeypatch.setattr(main.getpass, "getpass", lambda _prompt: next(answers))
+    monkeypatch.setattr("sys.argv", ["budget-forecaster", "hash-password"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.main()
+
+    assert exc_info.value.code == 1
+    assert "do not match" in capsys.readouterr().err
+
+
+def test_hash_password_exits_on_empty(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """hash-password rejects an empty password."""
+    monkeypatch.setattr(main.getpass, "getpass", lambda _prompt: "")
+    monkeypatch.setattr("sys.argv", ["budget-forecaster", "hash-password"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.main()
+
+    assert exc_info.value.code == 1
+    assert "must not be empty" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Deployment layer for the web app — the last sub-lot of #293. Makes the app run as a background service, reachable from phone and other PCs over Tailscale, with the bank sync on a daily timer. Almost entirely config artifacts + docs; one small code addition.

## What's included

- **systemd `--user` units** (`deploy/systemd/`): `budget-web.service` (uvicorn on `127.0.0.1`, `Restart=on-failure`), `budget-sync.service` + `budget-sync.timer` (daily, `Persistent=true`, records a `sync_runs` row).
- **`deploy/budget-web.env.example`**: secrets + config path, referenced by both units via `EnvironmentFile`.
- **`hash-password` CLI command**: prompts twice, prints a PBKDF2 hash for `BUDGET_WEB_PASSWORD_HASH` (config-independent). Replaces the copy-paste one-liner in the docs.
- **`docs/user/deployment.md`**: host-agnostic Linux guide (install, secrets, Tailscale `serve`, systemd, EB callback, access, updates) + host-specific prerequisites for Raspberry Pi / mini-PC and Windows via WSL2.

## Host portability

The units are pure Linux, identical on a Raspberry Pi / mini-PC and on WSL2. Only the bootstrap differs (WSL2: `systemd=true`, boot task, Tailscale userspace-networking fallback), documented as a short host-prerequisites section.

## Not included

Offline PWA read-only cache — deferred to a follow-up issue after this one.

## Test plan

- [x] `hash-password` prints a hash `verify_password` accepts; rejects mismatch + empty (pytest)
- [x] Full suite green (1137 passed)
- [x] pre-commit clean (ruff, black, mypy, pylint)

Closes #307. Targets `feature/293-web-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
