### PR TITLE
feat: Swile OAuth2 sync core (client, encrypted token store, API source)

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -23,6 +23,7 @@ budgetinterface
 cancelled
 cancelling
 categorizer
+ciphertext
 cli
 clôturé
 codecov
@@ -40,6 +41,10 @@ dataframe
 daterange
 datetime
 datetimes
+decrypt
+decrypt
+decrypting
+decrypts
 dedup
 deduping
 deduplicates
@@ -62,6 +67,7 @@ entrypoint
 enum
 enums
 env
+fernet
 focusable
 forecasted
 gettext
@@ -112,6 +118,7 @@ paribas
 parseable
 parsers
 passthrough
+plaintext
 polyline
 pragma
 pre
@@ -151,6 +158,7 @@ supermarché
 supersession
 svg
 swile
+swile's
 sys
 systemd
 tailnet
@@ -175,6 +183,7 @@ upsert
 upserting
 upserts
 uptime
+urlsafe
 uvicorn
 whitespace
 widget's

--- a/.custom.dic
+++ b/.custom.dic
@@ -42,7 +42,6 @@ daterange
 datetime
 datetimes
 decrypt
-decrypt
 decrypting
 decrypts
 dedup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,7 @@ repos:
           - pandas-stubs
           - python-dateutil
           - pyjwt
+          - cryptography
           - types-requests
           - fastapi
           - jinja2

--- a/budget_forecaster/core/types.py
+++ b/budget_forecaster/core/types.py
@@ -77,6 +77,13 @@ class SyncRunStatus(enum.StrEnum):
     FAILED = "FAILED"
 
 
+class SyncSource(enum.StrEnum):
+    """Which integration produced a sync run."""
+
+    ENABLE_BANKING = "enable_banking"
+    SWILE = "swile"
+
+
 class SyncRun(NamedTuple):
     """One recorded bank-sync run, for in-app alerting and history."""
 
@@ -96,6 +103,9 @@ class SyncRun(NamedTuple):
 
     error: str | None = None
     """Failure description ("ClassName: message"); set on failure."""
+
+    source: SyncSource = SyncSource.ENABLE_BANKING
+    """Integration that ran the sync."""
 
 
 class BudgetColumn(enum.StrEnum):

--- a/budget_forecaster/infrastructure/bank_sources/swile/swile_bank_adapter.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile/swile_bank_adapter.py
@@ -2,14 +2,15 @@
 import json
 import re
 import zipfile
-from datetime import datetime
 from pathlib import Path
 
-from budget_forecaster.core.amount import Amount
-from budget_forecaster.core.types import Category
 from budget_forecaster.exceptions import InvalidExportDataError
 from budget_forecaster.infrastructure.bank_sources.file_export_adapter import (
     FileExportAdapterBase,
+)
+from budget_forecaster.infrastructure.bank_sources.swile.swile_parser import (
+    parse_balance,
+    parse_operations,
 )
 from budget_forecaster.services.operation.historic_operation_factory import (
     HistoricOperationFactory,
@@ -29,53 +30,21 @@ class SwileBankAdapter(FileExportAdapterBase):
     ) -> None:
         """Load export from a swile-export-YYYY-MM-DD.zip archive.
 
-        The zip must contain operations.json and wallets.json at the root level.
+        The zip holds operations.json and wallets.json at the root. An export
+        with no meal-voucher transaction is rejected as invalid.
         """
         with zipfile.ZipFile(bank_export, "r") as zf:
             operations_json = json.loads(zf.read("operations.json"))
             wallets_json = json.loads(zf.read("wallets.json"))
 
-        for wallet in wallets_json["wallets"]:
-            if wallet["type"] == "meal_voucher":
-                if not isinstance(wallet["balance"]["value"], (float, int)):
-                    raise InvalidExportDataError(
-                        "The balance field should be a float",
-                        path=bank_export,
-                    )
-                self._balance = wallet["balance"]["value"]
-                break
-
-        for operation in operations_json["items"]:
-            for transaction in operation["transactions"]:
-                if transaction["status"] not in ("AUTHORIZED", "VALIDATED", "CAPTURED"):
-                    continue
-
-                if transaction["payment_method"] != "Wallets::MealVoucherWallet":
-                    # we only consider meal vouchers as the other transactions are deduced from the
-                    # main account
-                    continue
-
-                amount = transaction["amount"]["value"] / 100.0
-                # date has format "2025-01-24T13:50:50.073+01:00"
-                op_date = datetime.strptime(transaction["date"][:10], "%Y-%m-%d").date()
-                self._operations.append(
-                    operation_factory.create_operation(
-                        description=operation["name"],
-                        amount=Amount(
-                            amount, transaction["amount"]["currency"]["iso_3"]
-                        ),
-                        category=Category.UNCATEGORIZED,
-                        operation_date=op_date,
-                    )
-                )
-
-        if not self._operations:
+        self._balance = parse_balance(wallets_json, path=bank_export)
+        if not (operations := parse_operations(operations_json, operation_factory)):
             raise InvalidExportDataError(
                 "No meal voucher transactions found in the operations.json file",
                 path=bank_export,
             )
-
-        self._export_date = max(op.operation_date for op in self._operations)
+        self._operations = list(operations)
+        self._export_date = max(op.operation_date for op in operations)
 
     @classmethod
     def match(cls, bank_export: Path) -> bool:

--- a/budget_forecaster/infrastructure/bank_sources/swile/swile_parser.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile/swile_parser.py
@@ -1,0 +1,71 @@
+"""Pure parsing of Swile export payloads (operations + wallets).
+
+Shared by the file adapter (reads a downloaded zip) and the OAuth API source
+(fetches from Swile's endpoints). Only meal-voucher wallet transactions are
+kept: card payments are already deduced from the main bank account and would
+double-count.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.core.types import Category
+from budget_forecaster.domain.operation.historic_operation import HistoricOperation
+from budget_forecaster.exceptions import InvalidExportDataError
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+_MEAL_VOUCHER_STATUSES = ("AUTHORIZED", "VALIDATED", "CAPTURED")
+_MEAL_VOUCHER_PAYMENT_METHOD = "Wallets::MealVoucherWallet"
+
+
+def parse_balance(
+    wallets_payload: dict[str, Any], *, path: Path | None = None
+) -> float | None:
+    """Return the meal-voucher wallet balance, or None if there is no such wallet.
+
+    path is attached to the error when the balance value is malformed, so the
+    file adapter can point at the offending export.
+    """
+    for wallet in wallets_payload["wallets"]:
+        if wallet["type"] == "meal_voucher":
+            value = wallet["balance"]["value"]
+            if not isinstance(value, (float, int)):
+                raise InvalidExportDataError(
+                    "The balance field should be a float", path=path
+                )
+            return value
+    return None
+
+
+def parse_operations(
+    operations_payload: dict[str, Any],
+    operation_factory: HistoricOperationFactory,
+) -> tuple[HistoricOperation, ...]:
+    """Build the meal-voucher operations from an operations payload.
+
+    Empty when no meal-voucher transaction is present; the caller decides
+    whether that is an error (downloaded export) or expected (periodic sync).
+    """
+    operations: list[HistoricOperation] = []
+    for operation in operations_payload["items"]:
+        for transaction in operation["transactions"]:
+            if transaction["status"] not in _MEAL_VOUCHER_STATUSES:
+                continue
+            if transaction["payment_method"] != _MEAL_VOUCHER_PAYMENT_METHOD:
+                continue
+            amount = transaction["amount"]["value"] / 100.0
+            # date has format "2025-01-24T13:50:50.073+01:00"
+            op_date = datetime.strptime(transaction["date"][:10], "%Y-%m-%d").date()
+            operations.append(
+                operation_factory.create_operation(
+                    description=operation["name"],
+                    amount=Amount(amount, transaction["amount"]["currency"]["iso_3"]),
+                    category=Category.UNCATEGORIZED,
+                    operation_date=op_date,
+                )
+            )
+    return tuple(operations)

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/__init__.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/__init__.py
@@ -1,0 +1,1 @@
+"""Swile OAuth2 sync: refresh-token auth, server-side operation fetch."""

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
@@ -61,7 +61,7 @@ class SwileClient:
         shape the parser reads from a downloaded export.
         """
         items: list[dict[str, Any]] = []
-        cursor = datetime.now(timezone.utc).isoformat()
+        cursor: str | None = datetime.now(timezone.utc).isoformat()
         for _ in range(_MAX_PAGES):
             page = self._get(
                 constants.OPERATIONS_URL,
@@ -71,7 +71,8 @@ class SwileClient:
             items.extend(page.get("items", []))
             if not page.get("has_more"):
                 break
-            cursor = page["next_cursor"]
+            if not (cursor := page.get("next_cursor")):
+                break
         else:
             logger.warning(
                 "Swile operations hit the %d-page cap; older operations skipped",

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
@@ -1,0 +1,69 @@
+"""HTTP client for the unofficial Swile web API.
+
+Refreshes an access token from a refresh token, then reads operations and
+wallets. The access token lives 30 min; each refresh returns a new refresh
+token (soft rotation: the previous one stays valid). Auth uses the public web
+client_id and API key from constants.
+"""
+
+import logging
+from typing import Any, NamedTuple
+
+import requests
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth import constants
+
+logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 30
+
+
+class TokenBundle(NamedTuple):
+    """Tokens returned by a refresh call."""
+
+    access_token: str
+    refresh_token: str
+    expires_in: int
+
+
+class SwileClient:
+    """Client talking to the Swile web endpoints for a single user."""
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        self._session = session or requests.Session()
+
+    def refresh(self, refresh_token: str) -> TokenBundle:
+        """Exchange a refresh token for a fresh access token and rotated token."""
+        body = {
+            "grant_type": "refresh_token",
+            "client_id": constants.CLIENT_ID,
+            "refresh_token": refresh_token,
+        }
+        response = self._session.post(
+            constants.TOKEN_URL, json=body, timeout=_REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+        data = response.json()
+        return TokenBundle(
+            access_token=data["access_token"],
+            refresh_token=data["refresh_token"],
+            expires_in=data["expires_in"],
+        )
+
+    def get_operations(self, access_token: str) -> dict[str, Any]:
+        """Fetch the operations payload (same shape as the export operations.json)."""
+        return self._get(constants.OPERATIONS_URL, access_token)
+
+    def get_wallets(self, access_token: str) -> dict[str, Any]:
+        """Fetch the wallets payload (same shape as the export wallets.json)."""
+        return self._get(constants.WALLETS_URL, access_token)
+
+    def _get(self, url: str, access_token: str) -> dict[str, Any]:
+        """Send an authenticated GET and return the parsed JSON body."""
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "X-API-Key": constants.X_API_KEY,
+        }
+        response = self._session.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+        response.raise_for_status()
+        return response.json()

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
@@ -3,10 +3,12 @@
 Refreshes an access token from a refresh token, then reads operations and
 wallets. The access token lives 30 min; each refresh returns a new refresh
 token (soft rotation: the previous one stays valid). Auth uses the public web
-client_id and API key from constants.
+client_id and API key from constants. Headers and pagination mirror the export
+bookmarklet.
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import Any, NamedTuple
 
 import requests
@@ -16,6 +18,8 @@ from budget_forecaster.infrastructure.bank_sources.swile_oauth import constants
 logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = 30
+_ITEMS_PER_PAGE = 100
+_MAX_PAGES = 50  # ~5000 operations safety cap, as in the bookmarklet
 
 
 class TokenBundle(NamedTuple):
@@ -51,19 +55,55 @@ class SwileClient:
         )
 
     def get_operations(self, access_token: str) -> dict[str, Any]:
-        """Fetch the operations payload (same shape as the export operations.json)."""
-        return self._get(constants.OPERATIONS_URL, access_token)
+        """Fetch all operations, following the cursor pagination.
+
+        Returns an operations.json-shaped payload (an items list), the same
+        shape the parser reads from a downloaded export.
+        """
+        items: list[dict[str, Any]] = []
+        cursor = datetime.now(timezone.utc).isoformat()
+        for _ in range(_MAX_PAGES):
+            page = self._get(
+                constants.OPERATIONS_URL,
+                access_token,
+                params={"before": cursor, "per": _ITEMS_PER_PAGE},
+            )
+            items.extend(page.get("items", []))
+            if not page.get("has_more"):
+                break
+            cursor = page["next_cursor"]
+        else:
+            logger.warning(
+                "Swile operations hit the %d-page cap; older operations skipped",
+                _MAX_PAGES,
+            )
+        return {"items": items}
 
     def get_wallets(self, access_token: str) -> dict[str, Any]:
         """Fetch the wallets payload (same shape as the export wallets.json)."""
-        return self._get(constants.WALLETS_URL, access_token)
+        return self._get(
+            constants.WALLETS_URL, access_token, extra_headers={"X-API-Version": "0"}
+        )
 
-    def _get(self, url: str, access_token: str) -> dict[str, Any]:
+    def _get(
+        self,
+        url: str,
+        access_token: str,
+        *,
+        params: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         """Send an authenticated GET and return the parsed JSON body."""
         headers = {
             "Authorization": f"Bearer {access_token}",
             "X-API-Key": constants.X_API_KEY,
+            "X-Lunchr-Platform": "web",
+            "Content-Type": "application/json",
         }
-        response = self._session.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+        if extra_headers:
+            headers.update(extra_headers)
+        response = self._session.get(
+            url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         return response.json()

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/consent_service.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/consent_service.py
@@ -1,0 +1,52 @@
+"""Swile enrollment and token lifecycle.
+
+Wraps the client and token store: enroll a refresh token (validated by one
+refresh), mint an access token for a sync (re-storing the rotated refresh
+token), and report whether an enrollment exists. Holds no UI concern.
+"""
+
+import logging
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import SwileClient
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store import (
+    SwileTokenStore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NotEnrolledError(RuntimeError):
+    """Raised when a sync needs a refresh token but none is stored."""
+
+
+class SwileConsentService:
+    """Enroll, persist and refresh the Swile OAuth2 token."""
+
+    def __init__(self, client: SwileClient, store: SwileTokenStore) -> None:
+        self._client = client
+        self._store = store
+
+    def is_enrolled(self) -> bool:
+        """Return whether a refresh token is stored."""
+        return self._store.load() is not None
+
+    def enroll(self, refresh_token: str) -> None:
+        """Validate a refresh token with one refresh, then store the rotated token.
+
+        A bad token surfaces as the client's HTTP error, leaving nothing stored.
+        """
+        bundle = self._client.refresh(refresh_token)
+        self._store.save(bundle.refresh_token)
+        logger.info("Stored Swile refresh token")
+
+    def authenticate(self) -> str:
+        """Return a fresh access token, re-storing the rotated refresh token."""
+        if (refresh_token := self._store.load()) is None:
+            raise NotEnrolledError("No Swile refresh token stored; enroll first.")
+        bundle = self._client.refresh(refresh_token)
+        self._store.save(bundle.refresh_token)
+        return bundle.access_token
+
+    def clear(self) -> None:
+        """Forget the stored token."""
+        self._store.clear()

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/constants.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/constants.py
@@ -1,0 +1,14 @@
+"""Public Swile web constants.
+
+The client_id and API key are the ones the Swile web app ships to every
+browser; they are not secrets. The refresh token (per user) is the only
+credential and lives encrypted in the token store. These endpoints are
+unofficial and may change without notice.
+"""
+
+CLIENT_ID = "533bf5c8dbd05ef18fd01e2bbbab3d7f69e3511dd08402862b5de63b9a238923"
+X_API_KEY = "393e1b0abfebf6da88aa57cfa1a126f97bf0b818"
+
+TOKEN_URL = "https://directory.swile.co/oauth/token"
+OPERATIONS_URL = "https://neobank-api.swile.co/api/v3/user/operations"
+WALLETS_URL = "https://employee-bff-api.swile.co/api/wallets/get-wallets"

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/crypto.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/crypto.py
@@ -1,0 +1,30 @@
+"""Encrypt the Swile refresh token at rest.
+
+The Fernet key is derived from the web app's secret key (already mandatory)
+via HKDF-SHA256, so no extra secret has to be managed. The derived key is
+deterministic: the same secret key always decrypts a token it encrypted.
+"""
+
+import base64
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+_INFO = b"budget-forecaster/swile-oauth/refresh-token"
+
+
+def _fernet(secret_key: str) -> Fernet:
+    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=_INFO)
+    raw_key = hkdf.derive(secret_key.encode("utf-8"))
+    return Fernet(base64.urlsafe_b64encode(raw_key))
+
+
+def encrypt(token: str, secret_key: str) -> str:
+    """Encrypt a token; the result is a urlsafe ASCII string."""
+    return _fernet(secret_key).encrypt(token.encode("utf-8")).decode("ascii")
+
+
+def decrypt(blob: str, secret_key: str) -> str:
+    """Decrypt a blob produced by encrypt with the same secret key."""
+    return _fernet(secret_key).decrypt(blob.encode("ascii")).decode("utf-8")

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/source.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/source.py
@@ -1,0 +1,46 @@
+"""Swile OAuth2 API source."""
+
+import logging
+from datetime import date
+
+from budget_forecaster.infrastructure.bank_sources.bank_source import ApiBankSource
+from budget_forecaster.infrastructure.bank_sources.swile.swile_parser import (
+    parse_balance,
+    parse_operations,
+)
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import SwileClient
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SwileApiSource(ApiBankSource):
+    """Bank source fetching meal-voucher operations and balance from Swile.
+
+    Swile returns the whole user account in one call, so account_uid and
+    date_from are ignored; dedup keeps re-runs idempotent.
+    """
+
+    def __init__(self, client: SwileClient, access_token: str, name: str) -> None:
+        super().__init__(name)
+        self._client = client
+        self._access_token = access_token
+
+    def fetch(
+        self,
+        account_uid: str,
+        operation_factory: HistoricOperationFactory,
+        date_from: date | None = None,
+    ) -> None:
+        operations_payload = self._client.get_operations(self._access_token)
+        wallets_payload = self._client.get_wallets(self._access_token)
+        if operations_payload.get("has_more"):
+            logger.warning(
+                "Swile returned more operations than one page; only the first "
+                "page is synced (older operations arrive on later syncs)"
+            )
+        self._operations = list(parse_operations(operations_payload, operation_factory))
+        self._balance = parse_balance(wallets_payload)
+        self._export_date = date.today()

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/source.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/source.py
@@ -1,6 +1,5 @@
 """Swile OAuth2 API source."""
 
-import logging
 from datetime import date
 
 from budget_forecaster.infrastructure.bank_sources.bank_source import ApiBankSource
@@ -13,14 +12,12 @@ from budget_forecaster.services.operation.historic_operation_factory import (
     HistoricOperationFactory,
 )
 
-logger = logging.getLogger(__name__)
-
 
 class SwileApiSource(ApiBankSource):
     """Bank source fetching meal-voucher operations and balance from Swile.
 
-    Swile returns the whole user account in one call, so account_uid and
-    date_from are ignored; dedup keeps re-runs idempotent.
+    Swile returns the whole user account, so account_uid and date_from are
+    ignored; dedup keeps re-runs idempotent.
     """
 
     def __init__(self, client: SwileClient, access_token: str, name: str) -> None:
@@ -36,11 +33,6 @@ class SwileApiSource(ApiBankSource):
     ) -> None:
         operations_payload = self._client.get_operations(self._access_token)
         wallets_payload = self._client.get_wallets(self._access_token)
-        if operations_payload.get("has_more"):
-            logger.warning(
-                "Swile returned more operations than one page; only the first "
-                "page is synced (older operations arrive on later syncs)"
-            )
         self._operations = list(parse_operations(operations_payload, operation_factory))
         self._balance = parse_balance(wallets_payload)
         self._export_date = date.today()

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/sync_runner.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/sync_runner.py
@@ -1,0 +1,111 @@
+"""Run a Swile sync and record its outcome.
+
+Mirrors the Enable Banking sync runner: builds the SyncUseCase, records exactly
+one SyncRun (tagged source=swile), and never raises so callers branch on the
+returned status. A missing enrollment records a FAILED run pointing the user at
+re-enrollment.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from budget_forecaster.core.types import SyncRun, SyncRunStatus, SyncSource
+from budget_forecaster.domain.account.account_registry import AccountRegistry
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import SwileClient
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.consent_service import (
+    NotEnrolledError,
+    SwileConsentService,
+)
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.source import (
+    SwileApiSource,
+)
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store import (
+    SwileTokenStore,
+)
+from budget_forecaster.infrastructure.persistence.persistent_account import (
+    PersistentAccount,
+)
+from budget_forecaster.infrastructure.persistence.repository_interface import (
+    RepositoryInterface,
+)
+from budget_forecaster.services.bank_sync_service import BankSyncService
+from budget_forecaster.services.forecast.forecast_service import ForecastService
+from budget_forecaster.services.operation.operation_link_service import (
+    OperationLinkService,
+)
+from budget_forecaster.services.use_cases import MatcherCache, SyncUseCase
+
+logger = logging.getLogger(__name__)
+
+_ACCOUNT_NAME = "swile"
+# Swile fetches the whole account; the source ignores this uid.
+_ACCOUNT_UID = "swile"
+
+
+def perform_sync(
+    repository: RepositoryInterface,
+    token_store: SwileTokenStore,
+    accounts: AccountRegistry,
+    client: SwileClient | None = None,
+) -> SyncRun:
+    """Sync the enrolled Swile account, record the outcome, and return it.
+
+    Any failure is recorded as a FAILED run and returned; the exception does not
+    propagate.
+    """
+    ran_at = datetime.now(timezone.utc)
+    swile_client = client or SwileClient()
+    consent_service = SwileConsentService(swile_client, token_store)
+    try:
+        run = _sync(repository, consent_service, swile_client, accounts, ran_at)
+    except NotEnrolledError as error:
+        logger.warning("Swile sync skipped: %s", error)
+        run = SyncRun(
+            ran_at,
+            SyncRunStatus.FAILED,
+            error=_describe(error),
+            source=SyncSource.SWILE,
+        )
+    except Exception as error:  # pylint: disable=broad-except
+        logger.exception("Swile sync failed")
+        run = SyncRun(
+            ran_at,
+            SyncRunStatus.FAILED,
+            error=_describe(error),
+            source=SyncSource.SWILE,
+        )
+    repository.add_sync_run(run)
+    return run
+
+
+def _sync(
+    repository: RepositoryInterface,
+    consent_service: SwileConsentService,
+    client: SwileClient,
+    accounts: AccountRegistry,
+    ran_at: datetime,
+) -> SyncRun:
+    """Build the use case, run it, and build the success SyncRun."""
+    access_token = consent_service.authenticate()
+    persistent_account = PersistentAccount(repository)
+    source = SwileApiSource(client, access_token, name=_ACCOUNT_NAME)
+    sync_use_case = SyncUseCase(
+        BankSyncService(persistent_account, source, accounts),
+        persistent_account,
+        OperationLinkService(repository),
+        MatcherCache(ForecastService(persistent_account, repository)),
+    )
+    stats = sync_use_case.sync(_ACCOUNT_UID)
+    return SyncRun(
+        ran_at,
+        SyncRunStatus.OK,
+        new_count=stats.new_operations,
+        duplicate_count=stats.duplicates_skipped,
+        balance=persistent_account.account.balance,
+        source=SyncSource.SWILE,
+    )
+
+
+def _describe(error: Exception) -> str:
+    """Format an exception as "ClassName: message" for the sync-run record."""
+    return f"{type(error).__name__}: {error}"

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/token_store.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/token_store.py
@@ -1,0 +1,63 @@
+"""Persistence for the Swile refresh token.
+
+Mirrors the Enable Banking consent store: a single token under the XDG state
+directory, in a 0600 file. Unlike that store, the token is a live credential,
+so it is encrypted at rest with the web secret key.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.crypto import (
+    decrypt,
+    encrypt,
+)
+
+_STATE_SUBDIR = Path("budget-forecaster") / "swile_oauth"
+_TOKEN_FILENAME = "token.json"
+_OWNER_READ_WRITE = stat.S_IRUSR | stat.S_IWUSR
+
+
+class SwileTokenStore:
+    """Load and persist the encrypted Swile refresh token on disk."""
+
+    def __init__(self, path: Path, secret_key: str) -> None:
+        self._path = path
+        self._secret_key = secret_key
+
+    @classmethod
+    def default(cls, secret_key: str) -> "SwileTokenStore":
+        """Store under $XDG_STATE_HOME (fallback ~/.local/state)."""
+        return cls(_state_dir() / _STATE_SUBDIR / _TOKEN_FILENAME, secret_key)
+
+    @property
+    def path(self) -> Path:
+        """Path of the token file on disk."""
+        return self._path
+
+    def load(self) -> str | None:
+        """Return the stored refresh token, or None if none has been saved."""
+        if not self._path.exists():
+            return None
+        data = json.loads(self._path.read_text(encoding="utf-8"))
+        return decrypt(data["refresh_token"], self._secret_key)
+
+    def save(self, refresh_token: str) -> None:
+        """Persist the refresh token encrypted, restricting perms to the owner."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"refresh_token": encrypt(refresh_token, self._secret_key)}
+        self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.chmod(self._path, _OWNER_READ_WRITE)
+
+    def clear(self) -> None:
+        """Remove the stored token if present."""
+        self._path.unlink(missing_ok=True)
+
+
+def _state_dir() -> Path:
+    """Resolve the XDG state base directory."""
+    if xdg_state := os.environ.get("XDG_STATE_HOME"):
+        return Path(xdg_state)
+    return Path.home() / ".local" / "state"

--- a/budget_forecaster/infrastructure/persistence/migrations/v012_sync_run_source.sql
+++ b/budget_forecaster/infrastructure/persistence/migrations/v012_sync_run_source.sql
@@ -1,0 +1,2 @@
+-- v11 -> v12: tag each sync run with the integration that produced it
+ALTER TABLE sync_runs ADD COLUMN source TEXT NOT NULL DEFAULT 'enable_banking';

--- a/budget_forecaster/infrastructure/persistence/sqlite_repository.py
+++ b/budget_forecaster/infrastructure/persistence/sqlite_repository.py
@@ -26,6 +26,7 @@ from budget_forecaster.core.types import (
     OperationId,
     SyncRun,
     SyncRunStatus,
+    SyncSource,
     TargetId,
 )
 from budget_forecaster.domain.account.account import Account
@@ -812,8 +813,8 @@ class SqliteRepository(RepositoryInterface):
         conn = self._get_connection()
         conn.execute(
             """INSERT INTO sync_runs
-                   (ran_at, status, new_count, duplicate_count, balance, error)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+                   (ran_at, status, new_count, duplicate_count, balance, error, source)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (
                 run.ran_at.isoformat(),
                 run.status.value,
@@ -821,6 +822,7 @@ class SqliteRepository(RepositoryInterface):
                 run.duplicate_count,
                 run.balance,
                 run.error,
+                run.source.value,
             ),
         )
         conn.commit()
@@ -829,7 +831,7 @@ class SqliteRepository(RepositoryInterface):
         """Get the most recent sync runs, newest first."""
         conn = self._get_connection()
         cursor = conn.execute(
-            """SELECT ran_at, status, new_count, duplicate_count, balance, error
+            """SELECT ran_at, status, new_count, duplicate_count, balance, error, source
                FROM sync_runs ORDER BY id DESC LIMIT ?""",
             (limit,),
         )
@@ -841,6 +843,7 @@ class SqliteRepository(RepositoryInterface):
                 duplicate_count=row["duplicate_count"],
                 balance=row["balance"],
                 error=row["error"],
+                source=SyncSource(row["source"]),
             )
             for row in cursor.fetchall()
         )

--- a/tests/infrastructure/bank_sources/swile_oauth/test_client.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_client.py
@@ -1,0 +1,59 @@
+"""The Swile client refreshes tokens and reads operations/wallets."""
+
+from unittest.mock import MagicMock
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth import constants
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import (
+    SwileClient,
+    TokenBundle,
+)
+
+
+def _response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def test_refresh_posts_grant_and_returns_bundle() -> None:
+    """Refresh posts the grant body and returns the token bundle."""
+    session = MagicMock()
+    session.post.return_value = _response(
+        {"access_token": "acc", "refresh_token": "new-rt", "expires_in": 1800}
+    )
+
+    bundle = SwileClient(session).refresh("old-rt")
+
+    assert bundle == TokenBundle("acc", "new-rt", 1800)
+    call = session.post.call_args
+    assert call.args[0] == constants.TOKEN_URL
+    assert call.kwargs["json"] == {
+        "grant_type": "refresh_token",
+        "client_id": constants.CLIENT_ID,
+        "refresh_token": "old-rt",
+    }
+
+
+def test_get_operations_sends_bearer_and_api_key() -> None:
+    """get_operations authenticates with the bearer token and API key."""
+    session = MagicMock()
+    session.get.return_value = _response({"items": []})
+
+    payload = SwileClient(session).get_operations("acc-token")
+
+    assert payload == {"items": []}
+    call = session.get.call_args
+    assert call.args[0] == constants.OPERATIONS_URL
+    assert call.kwargs["headers"]["Authorization"] == "Bearer acc-token"
+    assert call.kwargs["headers"]["X-API-Key"] == constants.X_API_KEY
+
+
+def test_get_wallets_hits_the_wallets_endpoint() -> None:
+    """get_wallets calls the wallets endpoint."""
+    session = MagicMock()
+    session.get.return_value = _response({"wallets": []})
+
+    payload = SwileClient(session).get_wallets("acc-token")
+
+    assert payload == {"wallets": []}
+    assert session.get.call_args.args[0] == constants.WALLETS_URL

--- a/tests/infrastructure/bank_sources/swile_oauth/test_client.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_client.py
@@ -34,26 +34,45 @@ def test_refresh_posts_grant_and_returns_bundle() -> None:
     }
 
 
-def test_get_operations_sends_bearer_and_api_key() -> None:
-    """get_operations authenticates with the bearer token and API key."""
+def test_get_operations_sends_auth_headers_and_pagination_params() -> None:
+    """get_operations authenticates and asks for a page via before/per."""
     session = MagicMock()
-    session.get.return_value = _response({"items": []})
+    session.get.return_value = _response({"items": [{"name": "a"}], "has_more": False})
 
     payload = SwileClient(session).get_operations("acc-token")
 
-    assert payload == {"items": []}
+    assert payload == {"items": [{"name": "a"}]}
     call = session.get.call_args
     assert call.args[0] == constants.OPERATIONS_URL
-    assert call.kwargs["headers"]["Authorization"] == "Bearer acc-token"
-    assert call.kwargs["headers"]["X-API-Key"] == constants.X_API_KEY
+    headers = call.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer acc-token"
+    assert headers["X-API-Key"] == constants.X_API_KEY
+    assert headers["X-Lunchr-Platform"] == "web"
+    assert call.kwargs["params"]["per"] == 100
 
 
-def test_get_wallets_hits_the_wallets_endpoint() -> None:
-    """get_wallets calls the wallets endpoint."""
+def test_get_operations_follows_the_cursor_across_pages() -> None:
+    """Pagination follows next_cursor and concatenates items until has_more is false."""
+    session = MagicMock()
+    session.get.side_effect = [
+        _response({"items": [{"name": "a"}], "has_more": True, "next_cursor": "c2"}),
+        _response({"items": [{"name": "b"}], "has_more": False, "next_cursor": None}),
+    ]
+
+    payload = SwileClient(session).get_operations("acc-token")
+
+    assert payload == {"items": [{"name": "a"}, {"name": "b"}]}
+    assert session.get.call_args_list[1].kwargs["params"]["before"] == "c2"
+
+
+def test_get_wallets_sends_the_api_version_header() -> None:
+    """get_wallets hits the wallets endpoint with the X-API-Version header."""
     session = MagicMock()
     session.get.return_value = _response({"wallets": []})
 
     payload = SwileClient(session).get_wallets("acc-token")
 
     assert payload == {"wallets": []}
-    assert session.get.call_args.args[0] == constants.WALLETS_URL
+    call = session.get.call_args
+    assert call.args[0] == constants.WALLETS_URL
+    assert call.kwargs["headers"]["X-API-Version"] == "0"

--- a/tests/infrastructure/bank_sources/swile_oauth/test_client.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_client.py
@@ -1,9 +1,13 @@
 """The Swile client refreshes tokens and reads operations/wallets."""
 
+import logging
 from unittest.mock import MagicMock
+
+import pytest
 
 from budget_forecaster.infrastructure.bank_sources.swile_oauth import constants
 from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import (
+    _MAX_PAGES,
     SwileClient,
     TokenBundle,
 )
@@ -63,6 +67,37 @@ def test_get_operations_follows_the_cursor_across_pages() -> None:
 
     assert payload == {"items": [{"name": "a"}, {"name": "b"}]}
     assert session.get.call_args_list[1].kwargs["params"]["before"] == "c2"
+
+
+def test_get_operations_stops_on_missing_cursor() -> None:
+    """A has_more page without a next_cursor ends pagination instead of crashing."""
+    session = MagicMock()
+    session.get.side_effect = [
+        _response({"items": [{"name": "a"}], "has_more": True, "next_cursor": None}),
+    ]
+
+    payload = SwileClient(session).get_operations("acc-token")
+
+    assert payload == {"items": [{"name": "a"}]}
+    assert session.get.call_count == 1
+
+
+def test_get_operations_stops_at_the_page_cap_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pagination stops at the safety cap and warns instead of looping forever."""
+    session = MagicMock()
+    session.get.side_effect = [
+        _response({"items": [{"name": str(i)}], "has_more": True, "next_cursor": "c"})
+        for i in range(_MAX_PAGES + 5)
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        payload = SwileClient(session).get_operations("acc-token")
+
+    assert len(payload["items"]) == _MAX_PAGES
+    assert session.get.call_count == _MAX_PAGES
+    assert "page cap" in caplog.text
 
 
 def test_get_wallets_sends_the_api_version_header() -> None:

--- a/tests/infrastructure/bank_sources/swile_oauth/test_consent_service.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_consent_service.py
@@ -1,0 +1,76 @@
+"""Enrollment stores a rotated token; authenticate mints an access token."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import TokenBundle
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.consent_service import (
+    NotEnrolledError,
+    SwileConsentService,
+)
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store import (
+    SwileTokenStore,
+)
+
+
+def _service(
+    tmp_path: Path, client: MagicMock
+) -> tuple[SwileConsentService, SwileTokenStore]:
+    store = SwileTokenStore(tmp_path / "token.json", "web-secret-key")
+    return SwileConsentService(client, store), store
+
+
+def test_not_enrolled_before_enrollment(tmp_path: Path) -> None:
+    """No token stored reads as not enrolled."""
+    service, _ = _service(tmp_path, MagicMock())
+    assert service.is_enrolled() is False
+
+
+def test_enroll_stores_the_rotated_token(tmp_path: Path) -> None:
+    """Enroll validates the pasted token and stores the rotated one."""
+    client = MagicMock()
+    client.refresh.return_value = TokenBundle("acc", "rotated-rt", 1800)
+    service, store = _service(tmp_path, client)
+
+    service.enroll("pasted-rt")
+
+    client.refresh.assert_called_once_with("pasted-rt")
+    assert store.load() == "rotated-rt"
+    assert service.is_enrolled() is True
+
+
+def test_authenticate_refreshes_and_restores_token(tmp_path: Path) -> None:
+    """Authenticate returns the access token and re-stores the rotated token."""
+    client = MagicMock()
+    client.refresh.side_effect = [
+        TokenBundle("acc-1", "rt-2", 1800),
+        TokenBundle("acc-2", "rt-3", 1800),
+    ]
+    service, store = _service(tmp_path, client)
+    service.enroll("rt-1")
+
+    access_token = service.authenticate()
+
+    assert access_token == "acc-2"
+    assert store.load() == "rt-3"
+
+
+def test_authenticate_without_enrollment_raises(tmp_path: Path) -> None:
+    """Authenticate without a stored token raises NotEnrolledError."""
+    service, _ = _service(tmp_path, MagicMock())
+    with pytest.raises(NotEnrolledError):
+        service.authenticate()
+
+
+def test_clear_forgets_the_token(tmp_path: Path) -> None:
+    """Clear drops the enrollment."""
+    client = MagicMock()
+    client.refresh.return_value = TokenBundle("acc", "rt", 1800)
+    service, _ = _service(tmp_path, client)
+    service.enroll("rt-1")
+
+    service.clear()
+
+    assert service.is_enrolled() is False

--- a/tests/infrastructure/bank_sources/swile_oauth/test_crypto.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_crypto.py
@@ -1,0 +1,29 @@
+"""Refresh-token encryption round-trips and rejects the wrong key."""
+
+import pytest
+from cryptography.fernet import InvalidToken
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.crypto import (
+    decrypt,
+    encrypt,
+)
+
+_SECRET = "web-secret-key"
+_TOKEN = "opaque-refresh-token-43-chars-xxxxxxxxxxxxx"
+
+
+def test_round_trip_returns_original_token() -> None:
+    """Decrypting an encrypted token with the same key yields the original."""
+    assert decrypt(encrypt(_TOKEN, _SECRET), _SECRET) == _TOKEN
+
+
+def test_ciphertext_does_not_expose_the_token() -> None:
+    """The ciphertext does not contain the plaintext token."""
+    assert _TOKEN not in encrypt(_TOKEN, _SECRET)
+
+
+def test_wrong_key_cannot_decrypt() -> None:
+    """A different secret key fails to decrypt."""
+    blob = encrypt(_TOKEN, _SECRET)
+    with pytest.raises(InvalidToken):
+        decrypt(blob, "another-secret-key")

--- a/tests/infrastructure/bank_sources/swile_oauth/test_source.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_source.py
@@ -1,0 +1,55 @@
+"""The API source fetches, parses and exposes operations and balance."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.source import (
+    SwileApiSource,
+)
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+_OPERATIONS = {
+    "items": [
+        {
+            "name": "Restaurant",
+            "transactions": [
+                {
+                    "status": "CAPTURED",
+                    "payment_method": "Wallets::MealVoucherWallet",
+                    "date": "2025-01-15T13:50:50.073+01:00",
+                    "amount": {"value": -2500, "currency": {"iso_3": "EUR"}},
+                }
+            ],
+        }
+    ]
+}
+_WALLETS = {"wallets": [{"type": "meal_voucher", "balance": {"value": 100.0}}]}
+
+
+def test_fetch_populates_operations_balance_and_date() -> None:
+    """fetch fills operations, balance, and export date from the payloads."""
+    client = MagicMock()
+    client.get_operations.return_value = _OPERATIONS
+    client.get_wallets.return_value = _WALLETS
+    source = SwileApiSource(client, "acc-token", name="swile")
+
+    source.fetch("swile", HistoricOperationFactory(last_operation_id=0))
+
+    assert [op.amount for op in source.operations] == [-25.0]
+    assert source.balance == 100.0
+    assert source.export_date == date.today()
+
+
+def test_fetch_uses_the_injected_access_token() -> None:
+    """The stored access token is passed to both endpoint calls."""
+    client = MagicMock()
+    client.get_operations.return_value = _OPERATIONS
+    client.get_wallets.return_value = _WALLETS
+    source = SwileApiSource(client, "acc-token", name="swile")
+
+    source.fetch("swile", HistoricOperationFactory(last_operation_id=0))
+
+    client.get_operations.assert_called_once_with("acc-token")
+    client.get_wallets.assert_called_once_with("acc-token")

--- a/tests/infrastructure/bank_sources/swile_oauth/test_sync_runner.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_sync_runner.py
@@ -1,0 +1,126 @@
+"""perform_sync runs the Swile sync and records one SyncRun tagged swile."""
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from budget_forecaster.core.types import SyncRunStatus, SyncSource
+from budget_forecaster.domain.account.account import Account
+from budget_forecaster.domain.account.account_registry import AccountRegistry
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.client import TokenBundle
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.sync_runner import (
+    perform_sync,
+)
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store import (
+    SwileTokenStore,
+)
+from budget_forecaster.infrastructure.persistence.sqlite_repository import (
+    SqliteRepository,
+)
+
+ACCOUNT_NAME = "swile"
+
+_OPERATIONS = {
+    "items": [
+        {
+            "name": "Restaurant",
+            "transactions": [
+                {
+                    "status": "CAPTURED",
+                    "payment_method": "Wallets::MealVoucherWallet",
+                    "date": "2025-01-15T13:50:50.073+01:00",
+                    "amount": {"value": -2500, "currency": {"iso_3": "EUR"}},
+                }
+            ],
+        }
+    ]
+}
+_WALLETS = {"wallets": [{"type": "meal_voucher", "balance": {"value": 100.0}}]}
+
+
+@pytest.fixture(name="repository")
+def repository_fixture(tmp_path: Path) -> SqliteRepository:
+    """A real repository seeded with the Swile account the sync targets."""
+    repository = SqliteRepository(tmp_path / "test.db")
+    repository.initialize()
+    repository.set_aggregated_account_name("Test")
+    repository.upsert_account(
+        Account(
+            name=ACCOUNT_NAME,
+            balance=0.0,
+            currency="EUR",
+            balance_date=date(2025, 1, 1),
+            operations=(),
+        )
+    )
+    return repository
+
+
+@pytest.fixture(name="token_store")
+def token_store_fixture(tmp_path: Path) -> SwileTokenStore:
+    """A token store under a temp path."""
+    return SwileTokenStore(tmp_path / "token.json", "web-secret-key")
+
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    client.refresh.return_value = TokenBundle("acc", "rotated-rt", 1800)
+    client.get_operations.return_value = _OPERATIONS
+    client.get_wallets.return_value = _WALLETS
+    return client
+
+
+def test_success_records_ok_run(
+    repository: SqliteRepository, token_store: SwileTokenStore
+) -> None:
+    """A successful sync records an OK run tagged swile with its stats."""
+    token_store.save("stored-rt")
+
+    run = perform_sync(repository, token_store, AccountRegistry(), client=_client())
+
+    assert run.status is SyncRunStatus.OK
+    assert run.source is SyncSource.SWILE
+    assert run.new_count == 1
+    assert run.balance == 100.0
+    (recorded,) = repository.get_recent_sync_runs(1)
+    assert recorded == run
+
+
+def test_success_restores_rotated_token(
+    repository: SqliteRepository, token_store: SwileTokenStore
+) -> None:
+    """The rotated refresh token is persisted after a sync."""
+    token_store.save("stored-rt")
+
+    perform_sync(repository, token_store, AccountRegistry(), client=_client())
+
+    assert token_store.load() == "rotated-rt"
+
+
+def test_missing_enrollment_records_failed_run(
+    repository: SqliteRepository, token_store: SwileTokenStore
+) -> None:
+    """No stored token records a FAILED run, not propagated."""
+    run = perform_sync(repository, token_store, AccountRegistry(), client=_client())
+
+    assert run.status is SyncRunStatus.FAILED
+    assert run.source is SyncSource.SWILE
+    assert run.error is not None and "NotEnrolledError" in run.error
+    (recorded,) = repository.get_recent_sync_runs(1)
+    assert recorded.status is SyncRunStatus.FAILED
+
+
+def test_client_error_records_failed_run(
+    repository: SqliteRepository, token_store: SwileTokenStore
+) -> None:
+    """A refresh failure is recorded as a FAILED run."""
+    token_store.save("stored-rt")
+    client = _client()
+    client.refresh.side_effect = RuntimeError("token revoked")
+
+    run = perform_sync(repository, token_store, AccountRegistry(), client=client)
+
+    assert run.status is SyncRunStatus.FAILED
+    assert run.error == "RuntimeError: token revoked"

--- a/tests/infrastructure/bank_sources/swile_oauth/test_token_store.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_token_store.py
@@ -1,0 +1,44 @@
+"""The token store persists an encrypted token with owner-only perms."""
+
+import stat
+from pathlib import Path
+
+from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store import (
+    SwileTokenStore,
+)
+
+_SECRET = "web-secret-key"
+_TOKEN = "opaque-refresh-token"
+
+
+def _store(tmp_path: Path) -> SwileTokenStore:
+    return SwileTokenStore(tmp_path / "token.json", _SECRET)
+
+
+def test_load_returns_none_when_absent(tmp_path: Path) -> None:
+    """Loading before any save returns None."""
+    assert _store(tmp_path).load() is None
+
+
+def test_save_then_load_round_trips(tmp_path: Path) -> None:
+    """A saved token is read back unchanged."""
+    store = _store(tmp_path)
+    store.save(_TOKEN)
+    assert store.load() == _TOKEN
+
+
+def test_saved_file_is_encrypted_and_owner_only(tmp_path: Path) -> None:
+    """The file hides the plaintext token and is 0600."""
+    store = _store(tmp_path)
+    store.save(_TOKEN)
+    content = store.path.read_text(encoding="utf-8")
+    assert _TOKEN not in content
+    assert stat.S_IMODE(store.path.stat().st_mode) == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_clear_removes_the_token(tmp_path: Path) -> None:
+    """Clearing leaves nothing to load."""
+    store = _store(tmp_path)
+    store.save(_TOKEN)
+    store.clear()
+    assert store.load() is None

--- a/tests/infrastructure/bank_sources/test_swile_parser.py
+++ b/tests/infrastructure/bank_sources/test_swile_parser.py
@@ -1,0 +1,107 @@
+"""The Swile parser turns operations/wallets payloads into ops and balance."""
+
+from datetime import date
+
+import pytest
+
+from budget_forecaster.core.types import Category
+from budget_forecaster.exceptions import InvalidExportDataError
+from budget_forecaster.infrastructure.bank_sources.swile.swile_parser import (
+    parse_balance,
+    parse_operations,
+)
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+
+def _meal_voucher(name: str, value: int, day: str, status: str = "CAPTURED") -> dict:
+    return {
+        "name": name,
+        "transactions": [
+            {
+                "status": status,
+                "payment_method": "Wallets::MealVoucherWallet",
+                "date": f"{day}T13:50:50.073+01:00",
+                "amount": {"value": value, "currency": {"iso_3": "EUR"}},
+            }
+        ],
+    }
+
+
+@pytest.fixture(name="factory")
+def factory_fixture() -> HistoricOperationFactory:
+    """A factory starting operation ids at 1."""
+    return HistoricOperationFactory(last_operation_id=0)
+
+
+def test_parse_operations_keeps_meal_vouchers(
+    factory: HistoricOperationFactory,
+) -> None:
+    """Meal-voucher transactions become operations with euro amounts."""
+    payload = {
+        "items": [
+            _meal_voucher("Restaurant", -2500, "2025-01-15"),
+            _meal_voucher("Boulangerie", -800, "2025-01-16"),
+        ]
+    }
+
+    operations = parse_operations(payload, factory)
+
+    assert [op.amount for op in operations] == [-25.0, -8.0]
+    assert {op.description for op in operations} == {"Restaurant", "Boulangerie"}
+    assert all(op.category == Category.UNCATEGORIZED for op in operations)
+    assert operations[1].operation_date == date(2025, 1, 16)
+
+
+def test_parse_operations_skips_non_meal_voucher_and_declined(
+    factory: HistoricOperationFactory,
+) -> None:
+    """Card payments and declined transactions are dropped."""
+    payload = {
+        "items": [
+            {
+                "name": "Mixed",
+                "transactions": [
+                    {
+                        "status": "CAPTURED",
+                        "payment_method": "Wallets::CreditCardWallet",
+                        "date": "2025-01-15T00:00:00.000+01:00",
+                        "amount": {"value": -500, "currency": {"iso_3": "EUR"}},
+                    },
+                    {
+                        "status": "DECLINED",
+                        "payment_method": "Wallets::MealVoucherWallet",
+                        "date": "2025-01-15T00:00:00.000+01:00",
+                        "amount": {"value": -900, "currency": {"iso_3": "EUR"}},
+                    },
+                ],
+            }
+        ]
+    }
+
+    assert not parse_operations(payload, factory)
+
+
+def test_parse_balance_returns_meal_voucher_wallet() -> None:
+    """The meal-voucher wallet balance is returned as-is."""
+    payload = {
+        "wallets": [
+            {"type": "gift", "balance": {"value": 10.0}},
+            {"type": "meal_voucher", "balance": {"value": 125.5}},
+        ]
+    }
+    assert parse_balance(payload) == 125.5
+
+
+def test_parse_balance_none_without_meal_voucher_wallet() -> None:
+    """No meal-voucher wallet yields None."""
+    payload = {"wallets": [{"type": "gift", "balance": {"value": 10.0}}]}
+    assert parse_balance(payload) is None
+
+
+def test_parse_balance_rejects_non_numeric_value() -> None:
+    """A non-numeric balance value raises InvalidExportDataError."""
+    payload = {"wallets": [{"type": "meal_voucher", "balance": {"value": "bad"}}]}
+    with pytest.raises(InvalidExportDataError, match="balance field should be a float"):
+        parse_balance(payload)


### PR DESCRIPTION
## Context

PR1 of #325 (Swile OAuth2 sync). Adds the server-side core, no web UI yet. Mirrors the Enable Banking integration with an OAuth2 refresh token in place of a consent. Targets the `feature/325-swile-oauth-sync` branch.

## What's in

- **`swile_oauth` package**
  - `client.py` — refresh a refresh token into a 30-min access token (soft rotation), read operations + wallets with the public web `client_id` / API key.
  - `crypto.py` — Fernet encryption for the refresh token; the key is derived (HKDF-SHA256) from the web secret key, so no extra secret to manage.
  - `token_store.py` — encrypted, 0600 JSON store under the XDG state dir (same shape as the EB consent store, but encrypted since the token is a live credential).
  - `consent_service.py` — enroll (validate + store rotated token), authenticate (mint access token, re-store rotated token), is_enrolled, clear.
  - `source.py` — `SwileApiSource(ApiBankSource)` feeding the generic `BankSyncService` → `SyncUseCase` pipeline.
  - `sync_runner.py` — `perform_sync`, records exactly one `SyncRun` (never raises); a missing enrollment is a FAILED run.
- **Shared parser** — extracted `swile_parser` used by both the file adapter and the API source; the file adapter delegates to it (behaviour unchanged).
- **Sync-run source tag** — migration v012 adds a `source` column; `SyncSource` enum; EB runs default to `enable_banking`.

## Notes

- Enrollment / web routes / reconnect banner / bookmarklet / docs land in **PR2**.
- The operations fetch reads a single page; if Swile paginates (`has_more`), older operations arrive on later syncs (dedup keeps re-runs idempotent). Logged when it happens.
- No new runtime dependency: `cryptography` is already required; added to the mypy pre-commit deps for the first direct import.

## Tests

Unit tests for crypto round-trip, encrypted+0600 storage, client requests, enrollment/token lifecycle, the API source, the shared parser, and the sync runner (OK / not-enrolled / client-error). Full suite green (1004 passed).

Part of #325