### PR TITLE
docs: serve web app from Windows node on WSL2

### DIFF
--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -80,6 +80,11 @@ sudo tailscale serve --bg http://127.0.0.1:8000
 `tailscale serve` persists across reboots. Find your node name with `tailscale status`;
 the app is then reachable at `https://<node>.<tailnet>.ts.net`.
 
+> **On WSL2, do not run Tailscale inside the distro.** WSL's virtual NIC drops the
+> tailnet connection when the Windows host sleeps, leaving the node offline until you
+> restart WSL. Run Tailscale on the **Windows** host instead and let it proxy to the
+> app. Skip this step here and follow [Windows via WSL2](#windows-via-wsl2).
+
 ### 4. systemd services
 
 Install the units as user services (no root; they run under your account):
@@ -163,12 +168,35 @@ Install WSL2 with a recent Ubuntu, then:
 
    This boots the distro (and its systemd services) in the background.
 
-3. **Tailscale TUN fallback.** If `sudo tailscale up` reports no TUN device, run it in
-   userspace-networking mode:
+3. **Serve from the Windows host, not from WSL.** WSL's virtual NIC drops long-lived
+   connections when the host sleeps, so a Tailscale node running inside WSL goes offline
+   on resume until you restart WSL. The Windows Tailscale client reconnects reliably, so
+   run Tailscale there and have it proxy to the WSL app over `localhost`.
 
-   ```bash
-   sudo tailscaled --tun=userspace-networking &
-   sudo tailscale up
+   Install the Tailscale Windows client, sign in to the same tailnet, then from
+   PowerShell:
+
+   ```powershell
+   tailscale serve --bg http://localhost:8000
    ```
 
-Then follow the common setup.
+   The app is then reachable at `https://<windows-node>.<tailnet>.ts.net`. Windows
+   reaches the WSL uvicorn over `localhost` because WSL2 forwards it by default; if that
+   link becomes unreachable after a sleep/resume, set `networkingMode=mirrored` under
+   `[wsl2]` in `%USERPROFILE%\.wslconfig` and `wsl --shutdown`.
+
+   **Keep the hostname stable.** If a Tailscale node inside WSL already claimed the app
+   hostname, the Windows node registers with a `-1` suffix. To keep the bank callback
+   URL valid, stop and disable Tailscale in WSL (`sudo tailscale down`, then
+   `sudo systemctl disable --now tailscaled`), remove the offline WSL node in the
+   Tailscale admin console, rename the Windows node to the freed hostname, then re-issue
+   the serve config so it picks up the new name:
+
+   ```powershell
+   tailscale serve reset
+   tailscale serve --bg http://localhost:8000
+   ```
+
+The app and the sync timer still run under systemd inside WSL; only the tailnet entry
+point moves to Windows. Follow the common setup for everything except step 3
+(Tailscale), which the above replaces.

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -199,4 +199,6 @@ Install WSL2 with a recent Ubuntu, then:
 
 The app and the sync timer still run under systemd inside WSL; only the tailnet entry
 point moves to Windows. Follow the common setup for everything except step 3
-(Tailscale), which the above replaces.
+(Tailscale), which the above replaces. Where the common setup writes `<node>` (bank
+callback, Access), use the reclaimed hostname above — the whole point of reclaiming it
+is that `<node>` stays the same after moving to Windows.


### PR DESCRIPTION
## What

Document serving the web app from the **Windows** Tailscale node instead of from inside WSL.

## Why

On WSL2, the virtual NIC drops long-lived connections when the Windows host sleeps, so a Tailscale node running inside WSL loses its control-plane long-poll and is marked offline until WSL is manually restarted. The Windows Tailscale client reconnects reliably across sleep/resume. The app and the daily sync timer still run under systemd inside WSL; only the inbound tailnet entry point moves to Windows, which reverse-proxies to the WSL uvicorn over localhost.

The doc also covers reclaiming the app hostname on the Windows node (remove the WSL node, rename Windows to the freed name) so the registered Enable Banking callback URL stays valid, and `networkingMode=mirrored` as the fallback if localhost forwarding becomes unreliable after resume.

Verified live on the deployment host: reachable from a phone after a real sleep/resume with no manual WSL restart, single Tailscale node, unchanged MagicDNS hostname.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)