### PR TITLE
fix: dedup Swile API operations against earlier file imports

### DIFF
--- a/budget_forecaster/infrastructure/bank_sources/swile/swile_parser.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile/swile_parser.py
@@ -66,6 +66,7 @@ def parse_operations(
                     amount=Amount(amount, transaction["amount"]["currency"]["iso_3"]),
                     category=Category.UNCATEGORIZED,
                     operation_date=op_date,
+                    source_ref=transaction.get("id"),
                 )
             )
     return tuple(operations)

--- a/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
+++ b/budget_forecaster/infrastructure/bank_sources/swile_oauth/client.py
@@ -100,6 +100,10 @@ class SwileClient:
             "X-API-Key": constants.X_API_KEY,
             "X-Lunchr-Platform": "web",
             "Content-Type": "application/json",
+            # Swile returns operation names in the caller's language; without
+            # this the API defaults to English and won't dedup against French
+            # file imports.
+            "Accept-Language": "fr-FR",
         }
         if extra_headers:
             headers.update(extra_headers)

--- a/tests/infrastructure/bank_sources/swile_oauth/test_client.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_client.py
@@ -52,6 +52,7 @@ def test_get_operations_sends_auth_headers_and_pagination_params() -> None:
     assert headers["Authorization"] == "Bearer acc-token"
     assert headers["X-API-Key"] == constants.X_API_KEY
     assert headers["X-Lunchr-Platform"] == "web"
+    assert headers["Accept-Language"] == "fr-FR"
     assert call.kwargs["params"]["per"] == 100
 
 

--- a/tests/infrastructure/bank_sources/swile_oauth/test_source.py
+++ b/tests/infrastructure/bank_sources/swile_oauth/test_source.py
@@ -16,6 +16,7 @@ _OPERATIONS = {
             "name": "Restaurant",
             "transactions": [
                 {
+                    "id": "tx-1",
                     "status": "CAPTURED",
                     "payment_method": "Wallets::MealVoucherWallet",
                     "date": "2025-01-15T13:50:50.073+01:00",
@@ -38,6 +39,7 @@ def test_fetch_populates_operations_balance_and_date() -> None:
     source.fetch("swile", HistoricOperationFactory(last_operation_id=0))
 
     assert [op.amount for op in source.operations] == [-25.0]
+    assert [op.source_ref for op in source.operations] == ["tx-1"]
     assert source.balance == 100.0
     assert source.export_date == date.today()
 

--- a/tests/infrastructure/bank_sources/test_swile_dedup.py
+++ b/tests/infrastructure/bank_sources/test_swile_dedup.py
@@ -1,0 +1,78 @@
+"""Swile parser output reconciles against earlier file imports.
+
+A stored French file credit and an English-labeled API credit with the same
+amount and date collapse to one, since the parser now carries the transaction
+id as the source ref.
+"""
+
+from datetime import date
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.core.types import Category
+from budget_forecaster.domain.account.account import Account, AccountParameters
+from budget_forecaster.domain.account.aggregated_account import AggregatedAccount
+from budget_forecaster.domain.operation.historic_operation import HistoricOperation
+from budget_forecaster.infrastructure.bank_sources.swile.swile_parser import (
+    parse_operations,
+)
+from budget_forecaster.services.operation.historic_operation_factory import (
+    HistoricOperationFactory,
+)
+
+
+def _api_credit_payload(label: str, value: int, day: str, tx_id: str) -> dict:
+    return {
+        "items": [
+            {
+                "name": label,
+                "transactions": [
+                    {
+                        "id": tx_id,
+                        "status": "CAPTURED",
+                        "payment_method": "Wallets::MealVoucherWallet",
+                        "date": f"{day}T13:50:50.073+01:00",
+                        "amount": {"value": value, "currency": {"iso_3": "EUR"}},
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_english_api_credit_reconciles_against_french_file_credit() -> None:
+    """An API op with a different label collapses onto the stored file op."""
+    french_file_op = HistoricOperation(
+        unique_id=1,
+        description="Crédit titres-restaurant",
+        amount=Amount(198.0),
+        category=Category.UNCATEGORIZED,
+        operation_date=date(2025, 1, 5),
+        source_ref=None,
+    )
+    current = Account(
+        name="swile",
+        balance=198.0,
+        currency="EUR",
+        balance_date=date(2025, 1, 15),
+        operations=(french_file_op,),
+    )
+
+    parsed = parse_operations(
+        _api_credit_payload("Meal voucher credit", 19800, "2025-01-05", "tx-credit"),
+        HistoricOperationFactory(last_operation_id=1),
+    )
+
+    result = AggregatedAccount.update_account(
+        current,
+        AccountParameters(
+            name="swile",
+            balance=198.0,
+            currency="EUR",
+            balance_date=date(2025, 1, 15),
+            operations=parsed,
+        ),
+    )
+
+    assert result.stats.duplicates_skipped == 1
+    assert len(result.account.operations) == 1
+    assert result.account.operations[0].source_ref == "tx-credit"

--- a/tests/infrastructure/bank_sources/test_swile_parser.py
+++ b/tests/infrastructure/bank_sources/test_swile_parser.py
@@ -15,11 +15,14 @@ from budget_forecaster.services.operation.historic_operation_factory import (
 )
 
 
-def _meal_voucher(name: str, value: int, day: str, status: str = "CAPTURED") -> dict:
+def _meal_voucher(
+    name: str, value: int, day: str, status: str = "CAPTURED", tx_id: str = "tx-1"
+) -> dict:
     return {
         "name": name,
         "transactions": [
             {
+                "id": tx_id,
                 "status": status,
                 "payment_method": "Wallets::MealVoucherWallet",
                 "date": f"{day}T13:50:50.073+01:00",
@@ -52,6 +55,34 @@ def test_parse_operations_keeps_meal_vouchers(
     assert {op.description for op in operations} == {"Restaurant", "Boulangerie"}
     assert all(op.category == Category.UNCATEGORIZED for op in operations)
     assert operations[1].operation_date == date(2025, 1, 16)
+
+
+def test_parse_operations_carries_transaction_id_as_source_ref(
+    factory: HistoricOperationFactory,
+) -> None:
+    """The transaction id becomes the source ref, so dedup survives label drift."""
+    payload = {
+        "items": [_meal_voucher("Restaurant", -2500, "2025-01-15", tx_id="tx-9")]
+    }
+
+    operations = parse_operations(payload, factory)
+
+    assert operations[0].source_ref == "tx-9"
+
+
+def test_parse_operations_source_ref_none_without_transaction_id(
+    factory: HistoricOperationFactory,
+) -> None:
+    """A transaction with no id falls back to a content-based dedup key."""
+    transaction = {
+        "status": "CAPTURED",
+        "payment_method": "Wallets::MealVoucherWallet",
+        "date": "2025-01-15T13:50:50.073+01:00",
+        "amount": {"value": -2500, "currency": {"iso_3": "EUR"}},
+    }
+    payload = {"items": [{"name": "Restaurant", "transactions": [transaction]}]}
+
+    assert parse_operations(payload, factory)[0].source_ref is None
 
 
 def test_parse_operations_skips_non_meal_voucher_and_declined(


### PR DESCRIPTION
## Problem

After enabling the Swile OAuth sync, meal-voucher **credits** appeared twice in the ledger: once from earlier zip imports, once from the API sync.

Root cause: Swile localises the credit label, and the API — called without an `Accept-Language` header — returned it in English while the earlier file imports had stored it in French. Operation dedup keys on description + amount + date, so the differing label produced a different key and the credit was not recognised as already present. Card-payment debits carry the merchant name (not localised), so they were unaffected — which is why only credits doubled.

The cross-source reconciliation that would otherwise catch this (match by signed amount and a small date window) never fired, because it requires exactly one side to carry a `source_ref`, and the Swile parser never set one (unlike the Enable Banking path).

## Fix

- Send `Accept-Language: fr-FR` from the Swile client, so API operation names match a French export and dedup against earlier file imports.
- Carry the Swile transaction id as the operation `source_ref` (mirroring the Enable Banking adapter). Re-runs stay idempotent by exact ref, and any future label drift is reconciled by amount + date against existing file operations instead of doubling.

## Tests

- Parser sets `source_ref` from the transaction id, and falls back to a content key when the id is absent.
- Client sends the `Accept-Language` header.
- API source exposes the source ref end to end.

Full suite green (1032 passed).

## Note

This stops **new** duplicates. The credits already doubled in the live database are cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)