### PR TITLE
feat: backup restore, preview and cross-process lock (PR1)

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -70,6 +70,7 @@ enum
 enums
 env
 fernet
+filesystem
 focusable
 forecasted
 gettext
@@ -117,6 +118,7 @@ oauth
 oob
 opérations
 orchestrator
+os
 overridable
 params
 paribas
@@ -130,6 +132,7 @@ pre
 prefilled
 prefilling
 preformatted
+prerestore
 prs
 prévu
 pytest
@@ -145,6 +148,7 @@ repo
 repointed
 repr
 reproducibility
+restore's
 revenus
 rmul
 rsa
@@ -193,6 +197,7 @@ upserts
 uptime
 urlsafe
 uvicorn
+wal
 whitespace
 widget's
 xdg

--- a/budget_forecaster/infrastructure/backup.py
+++ b/budget_forecaster/infrastructure/backup.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, NamedTuple
@@ -28,6 +29,10 @@ class BackupService:
     """Service for creating, rotating and restoring database backups."""
 
     TIMESTAMP_FORMAT = "%Y-%m-%d_%H%M%S"
+    # Filenames carry microseconds so two backups in the same second never
+    # collide (a rapid restore then undo would otherwise overwrite its own
+    # safety snapshot). Parsing accepts the second-only form for older files.
+    _FILENAME_TIMESTAMP_FORMAT = "%Y-%m-%d_%H%M%S_%f"
 
     def __init__(
         self,
@@ -47,7 +52,9 @@ class BackupService:
         self._database_path = database_path
         self._backup_directory = backup_directory or database_path.parent
         self._max_backups = max_backups
-        self._max_safety_backups = max_safety_backups
+        # Always keep at least the snapshot a restore just took, so it is never
+        # rotated away before the caller can use it to undo.
+        self._max_safety_backups = max(1, max_safety_backups)
         self._db_stem = database_path.stem
 
     @property
@@ -72,10 +79,12 @@ class BackupService:
         """Read the timestamp from a backup filename, falling back to mtime."""
         suffix = path.stem.removeprefix(f"{self._db_stem}_")
         suffix = suffix.removeprefix(f"{_SAFETY_MARKER}_")
-        try:
-            return datetime.strptime(suffix, self.TIMESTAMP_FORMAT)
-        except ValueError:
-            return datetime.fromtimestamp(path.stat().st_mtime)
+        for fmt in (self._FILENAME_TIMESTAMP_FORMAT, self.TIMESTAMP_FORMAT):
+            try:
+                return datetime.strptime(suffix, fmt)
+            except ValueError:
+                continue
+        return datetime.fromtimestamp(path.stat().st_mtime)
 
     def create_backup(self, safety: bool = False) -> Path:
         """Create a backup of the database.
@@ -95,7 +104,7 @@ class BackupService:
 
         try:
             self._backup_directory.mkdir(parents=True, exist_ok=True)
-            timestamp = datetime.now().strftime(self.TIMESTAMP_FORMAT)
+            timestamp = datetime.now().strftime(self._FILENAME_TIMESTAMP_FORMAT)
             marker = f"{_SAFETY_MARKER}_" if safety else ""
             backup_path = (
                 self._backup_directory / f"{self._db_stem}_{marker}{timestamp}.db"
@@ -120,7 +129,7 @@ class BackupService:
         deleted += self._rotate(self._safety_backups(), self._max_safety_backups)
         return deleted
 
-    def _rotate(self, backups: list[Path], keep: int) -> list[Path]:
+    def _rotate(self, backups: tuple[Path, ...], keep: int) -> tuple[Path, ...]:
         """Delete all but the newest keep backups (input sorted oldest first)."""
         deleted: list[Path] = []
         for backup in backups[:-keep] if keep else backups:
@@ -130,20 +139,22 @@ class BackupService:
                 logger.info("Deleted old backup: %s", backup)
             except OSError as e:
                 logger.error("Failed to delete backup %s: %s", backup, e)
-        return deleted
+        return tuple(deleted)
 
     def get_existing_backups(self) -> list[Path]:
         """Get all backup files (automatic and safety), sorted oldest first."""
         backups = list(self._backup_directory.glob(self._get_backup_pattern()))
         return sorted(backups, key=lambda p: p.stat().st_mtime)
 
-    def _automatic_backups(self) -> list[Path]:
+    def _automatic_backups(self) -> tuple[Path, ...]:
         """Automatic backups only, sorted oldest first."""
-        return [p for p in self.get_existing_backups() if not self._is_safety_copy(p)]
+        return tuple(
+            p for p in self.get_existing_backups() if not self._is_safety_copy(p)
+        )
 
-    def _safety_backups(self) -> list[Path]:
+    def _safety_backups(self) -> tuple[Path, ...]:
         """Pre-restore snapshots only, sorted oldest first."""
-        return [p for p in self.get_existing_backups() if self._is_safety_copy(p)]
+        return tuple(p for p in self.get_existing_backups() if self._is_safety_copy(p))
 
     def get_backups(self) -> tuple[BackupInfo, ...]:
         """List all backups, newest first, with metadata for the UI."""
@@ -220,7 +231,7 @@ class BackupService:
                 shutil.copy2(source, scratch)
                 migrate(scratch)
                 os.replace(scratch, self._database_path)
-            except OSError as e:
+            except (OSError, sqlite3.Error) as e:
                 raise BackupError(f"Failed to restore backup: {filename!r}") from e
             finally:
                 scratch.unlink(missing_ok=True)

--- a/budget_forecaster/infrastructure/backup.py
+++ b/budget_forecaster/infrastructure/backup.py
@@ -1,17 +1,31 @@
 """Backup service for automatic database backups."""
 
 import logging
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
+from typing import Callable, NamedTuple
 
 from budget_forecaster.exceptions import BackupError
+from budget_forecaster.infrastructure.db_lock import database_lock
 
 logger = logging.getLogger(__name__)
 
+_SAFETY_MARKER = "prerestore"
+
+
+class BackupInfo(NamedTuple):
+    """A backup file surfaced to the UI."""
+
+    path: Path
+    timestamp: datetime
+    size_bytes: int
+    is_safety_copy: bool
+
 
 class BackupService:
-    """Service for creating and rotating database backups."""
+    """Service for creating, rotating and restoring database backups."""
 
     TIMESTAMP_FORMAT = "%Y-%m-%d_%H%M%S"
 
@@ -20,17 +34,20 @@ class BackupService:
         database_path: Path,
         backup_directory: Path | None = None,
         max_backups: int = 5,
+        max_safety_backups: int = 3,
     ) -> None:
         """Initialize the backup service.
 
         Args:
             database_path: Path to the SQLite database file.
             backup_directory: Directory for backups (default: same as database).
-            max_backups: Maximum number of backups to keep.
+            max_backups: Maximum number of automatic backups to keep.
+            max_safety_backups: Maximum number of pre-restore snapshots to keep.
         """
         self._database_path = database_path
         self._backup_directory = backup_directory or database_path.parent
         self._max_backups = max_backups
+        self._max_safety_backups = max_safety_backups
         self._db_stem = database_path.stem
 
     @property
@@ -40,15 +57,32 @@ class BackupService:
 
     @property
     def max_backups(self) -> int:
-        """Return the maximum number of backups to keep."""
+        """Return the maximum number of automatic backups to keep."""
         return self._max_backups
 
     def _get_backup_pattern(self) -> str:
         """Get the glob pattern for backup files."""
         return f"{self._db_stem}_*.db"
 
-    def create_backup(self) -> Path:
+    def _is_safety_copy(self, path: Path) -> bool:
+        """Whether a backup file is a pre-restore safety snapshot."""
+        return path.stem.startswith(f"{self._db_stem}_{_SAFETY_MARKER}_")
+
+    def _parse_timestamp(self, path: Path) -> datetime:
+        """Read the timestamp from a backup filename, falling back to mtime."""
+        suffix = path.stem.removeprefix(f"{self._db_stem}_")
+        suffix = suffix.removeprefix(f"{_SAFETY_MARKER}_")
+        try:
+            return datetime.strptime(suffix, self.TIMESTAMP_FORMAT)
+        except ValueError:
+            return datetime.fromtimestamp(path.stat().st_mtime)
+
+    def create_backup(self, safety: bool = False) -> Path:
         """Create a backup of the database.
+
+        Args:
+            safety: When True, name it as a pre-restore snapshot rotated on its
+                own counter rather than mixed with automatic backups.
 
         Returns:
             Path to the created backup file.
@@ -60,59 +94,153 @@ class BackupService:
             raise BackupError(f"Database file does not exist: {self._database_path}")
 
         try:
-            # Create backup directory if needed
             self._backup_directory.mkdir(parents=True, exist_ok=True)
-
-            # Generate backup filename with timestamp
             timestamp = datetime.now().strftime(self.TIMESTAMP_FORMAT)
-            backup_filename = f"{self._db_stem}_{timestamp}.db"
-            backup_path = self._backup_directory / backup_filename
-
-            # Copy the database file
+            marker = f"{_SAFETY_MARKER}_" if safety else ""
+            backup_path = (
+                self._backup_directory / f"{self._db_stem}_{marker}{timestamp}.db"
+            )
             shutil.copy2(self._database_path, backup_path)
             logger.info("Database backup created: %s", backup_path)
-
             return backup_path
-
         except OSError as e:
             raise BackupError("Failed to create backup") from e
 
     def rotate_backups(self) -> list[Path]:
-        """Delete old backups exceeding max_backups.
+        """Delete backups exceeding the per-kind caps.
+
+        Automatic and pre-restore snapshots rotate independently, so a restore's
+        safety snapshot never evicts an automatic backup the user still wants.
 
         Returns:
             List of deleted backup file paths.
         """
         deleted: list[Path] = []
+        deleted += self._rotate(self._automatic_backups(), self._max_backups)
+        deleted += self._rotate(self._safety_backups(), self._max_safety_backups)
+        return deleted
 
-        try:
-            backups = self.get_existing_backups()
-
-            if len(backups) <= self._max_backups:
-                return deleted
-
-            # Delete oldest backups (list is sorted oldest first)
-            to_delete = backups[: -self._max_backups]
-
-            for backup in to_delete:
-                try:
-                    backup.unlink()
-                    deleted.append(backup)
-                    logger.info("Deleted old backup: %s", backup)
-                except OSError as e:
-                    logger.error("Failed to delete backup %s: %s", backup, e)
-
-        except OSError as e:
-            logger.error("Failed to rotate backups: %s", e)
-
+    def _rotate(self, backups: list[Path], keep: int) -> list[Path]:
+        """Delete all but the newest keep backups (input sorted oldest first)."""
+        deleted: list[Path] = []
+        for backup in backups[:-keep] if keep else backups:
+            try:
+                backup.unlink()
+                deleted.append(backup)
+                logger.info("Deleted old backup: %s", backup)
+            except OSError as e:
+                logger.error("Failed to delete backup %s: %s", backup, e)
         return deleted
 
     def get_existing_backups(self) -> list[Path]:
-        """Get list of existing backup files sorted by modification time.
+        """Get all backup files (automatic and safety), sorted oldest first."""
+        backups = list(self._backup_directory.glob(self._get_backup_pattern()))
+        return sorted(backups, key=lambda p: p.stat().st_mtime)
+
+    def _automatic_backups(self) -> list[Path]:
+        """Automatic backups only, sorted oldest first."""
+        return [p for p in self.get_existing_backups() if not self._is_safety_copy(p)]
+
+    def _safety_backups(self) -> list[Path]:
+        """Pre-restore snapshots only, sorted oldest first."""
+        return [p for p in self.get_existing_backups() if self._is_safety_copy(p)]
+
+    def get_backups(self) -> tuple[BackupInfo, ...]:
+        """List all backups, newest first, with metadata for the UI."""
+        infos = [
+            BackupInfo(
+                path=p,
+                timestamp=self._parse_timestamp(p),
+                size_bytes=p.stat().st_size,
+                is_safety_copy=self._is_safety_copy(p),
+            )
+            for p in self.get_existing_backups()
+        ]
+        return tuple(sorted(infos, key=lambda i: i.timestamp, reverse=True))
+
+    def resolve_backup(self, filename: str) -> Path:
+        """Resolve a bare filename to a backup path, rejecting anything else.
+
+        Guards against path traversal: the name must have no directory part and
+        must resolve to an existing file inside the backup directory that matches
+        the backup naming pattern.
+
+        Raises:
+            BackupError: If the name is not a valid backup in this directory.
+        """
+        if filename != Path(filename).name:
+            raise BackupError(f"Invalid backup name: {filename!r}")
+        if (path := self._backup_directory / filename) not in set(
+            self.get_existing_backups()
+        ):
+            raise BackupError(f"Unknown backup: {filename!r}")
+        return path
+
+    def delete_backup(self, filename: str) -> None:
+        """Delete a single backup by filename.
+
+        Raises:
+            BackupError: If the name is not a valid backup or the delete fails.
+        """
+        path = self.resolve_backup(filename)
+        try:
+            path.unlink()
+            logger.info("Deleted backup: %s", path)
+        except OSError as e:
+            raise BackupError(f"Failed to delete backup: {filename!r}") from e
+
+    def restore_backup(self, filename: str, migrate: Callable[[Path], None]) -> Path:
+        """Restore a backup over the live database.
+
+        Takes a pre-restore safety snapshot, migrates a scratch copy of the
+        chosen backup to the current schema, then atomically swaps it into place.
+        Held under the cross-process database lock so a concurrent sync cannot
+        write into the file being replaced. The caller must close its own
+        connection before and reload after.
+
+        Args:
+            filename: Name of the backup to restore (validated).
+            migrate: Callback that upgrades the given scratch file to the current
+                schema; must raise on failure so no swap happens.
 
         Returns:
-            List of backup file paths, sorted oldest first.
+            Path to the pre-restore safety snapshot (restore it to undo).
+
+        Raises:
+            BackupError: On an invalid source, a cross-device backup directory,
+                a failed migration, or a failed file operation.
         """
-        pattern = self._get_backup_pattern()
-        backups = list(self._backup_directory.glob(pattern))
-        return sorted(backups, key=lambda p: p.stat().st_mtime)
+        source = self.resolve_backup(filename)
+        self._require_same_filesystem()
+
+        with database_lock(self._database_path):
+            snapshot = self.create_backup(safety=True)
+            scratch = self._backup_directory / f".restore-{self._db_stem}.tmp"
+            try:
+                shutil.copy2(source, scratch)
+                migrate(scratch)
+                os.replace(scratch, self._database_path)
+            except OSError as e:
+                raise BackupError(f"Failed to restore backup: {filename!r}") from e
+            finally:
+                scratch.unlink(missing_ok=True)
+            self._remove_stale_sidecars()
+            self._rotate(self._safety_backups(), self._max_safety_backups)
+        return snapshot
+
+    def _require_same_filesystem(self) -> None:
+        """Ensure backup dir and database share a filesystem (for os.replace)."""
+        if (
+            self._backup_directory.stat().st_dev
+            != self._database_path.parent.stat().st_dev
+        ):
+            raise BackupError(
+                "Backup directory and database must be on the same filesystem"
+            )
+
+    def _remove_stale_sidecars(self) -> None:
+        """Remove leftover WAL sidecars of the live DB (defensive; mode is delete)."""
+        for suffix in ("-wal", "-shm"):
+            self._database_path.with_name(self._database_path.name + suffix).unlink(
+                missing_ok=True
+            )

--- a/budget_forecaster/infrastructure/backup_preview.py
+++ b/budget_forecaster/infrastructure/backup_preview.py
@@ -1,0 +1,82 @@
+"""Read-only preview of a backup before restoring it.
+
+Reads lightweight metrics straight from the backup file on a read-only
+connection, without touching the live connection or running migrations, so a
+preview never affects other viewers and works on older-schema backups.
+"""
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.exceptions import BackupError
+
+
+class BackupMetrics(NamedTuple):
+    """Summary metrics of a single database file."""
+
+    total_balance: Amount
+    operation_count: int
+    latest_operation_date: date | None
+    schema_version: int
+
+
+class BackupPreview(NamedTuple):
+    """Current database and a candidate backup, side by side."""
+
+    current: BackupMetrics
+    backup: BackupMetrics
+
+
+def preview_backup(database_path: Path, backup_path: Path) -> BackupPreview:
+    """Compute metrics for the live database and a backup for comparison.
+
+    Raises:
+        BackupError: If either file cannot be read as a database.
+    """
+    return BackupPreview(
+        current=_read_metrics(database_path),
+        backup=_read_metrics(backup_path),
+    )
+
+
+def _read_metrics(path: Path) -> BackupMetrics:
+    """Read summary metrics from a database file on a read-only connection."""
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.OperationalError as e:
+        raise BackupError(f"Cannot open database: {path.name}") from e
+    conn.row_factory = sqlite3.Row
+    try:
+        currency = _scalar(conn, "SELECT currency FROM accounts LIMIT 1") or "EUR"
+        balance = _scalar(conn, "SELECT SUM(balance) FROM accounts") or 0.0
+        count = _scalar(conn, "SELECT COUNT(*) FROM operations") or 0
+        latest = _scalar(conn, "SELECT MAX(date) FROM operations")
+        version = _schema_version(conn)
+    except sqlite3.DatabaseError as e:
+        raise BackupError(f"Cannot read database: {path.name}") from e
+    finally:
+        conn.close()
+
+    return BackupMetrics(
+        total_balance=Amount(float(balance), currency),
+        operation_count=int(count),
+        latest_operation_date=date.fromisoformat(latest) if latest else None,
+        schema_version=version,
+    )
+
+
+def _scalar(conn: sqlite3.Connection, query: str) -> Any:
+    """Run a query and return the first column of the first row, or None."""
+    row = conn.execute(query).fetchone()
+    return row[0] if row else None
+
+
+def _schema_version(conn: sqlite3.Connection) -> int:
+    """Read the schema version, or 0 if the table is absent."""
+    try:
+        return int(_scalar(conn, "SELECT version FROM schema_version LIMIT 1") or 0)
+    except sqlite3.OperationalError:
+        return 0

--- a/budget_forecaster/infrastructure/db_lock.py
+++ b/budget_forecaster/infrastructure/db_lock.py
@@ -1,0 +1,38 @@
+"""Cross-process advisory lock on the database file.
+
+The web app and the sync command are separate processes on the same SQLite file.
+A restore swaps the file, so it must not run while the sync holds the database
+open, and vice versa. An in-process connection close does not guard against a
+second process; both paths take this lock.
+"""
+
+import fcntl
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+def _lock_path(database_path: Path) -> Path:
+    """Return the lock file path sitting next to the database."""
+    return database_path.with_name(f"{database_path.name}.lock")
+
+
+@contextmanager
+def database_lock(database_path: Path) -> Iterator[None]:
+    """Hold an exclusive advisory lock on the database for the block's duration.
+
+    Blocks until the lock is free. Released on block exit and on process death.
+    """
+    path = _lock_path(database_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        logger.debug("Acquiring database lock: %s", path)
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+            logger.debug("Released database lock: %s", path)

--- a/budget_forecaster/main.py
+++ b/budget_forecaster/main.py
@@ -23,6 +23,7 @@ from budget_forecaster.infrastructure.bank_sources.swile_oauth.token_store impor
 from budget_forecaster.infrastructure.bank_sources.sync_all import sync_all_sources
 from budget_forecaster.infrastructure.bootstrap import open_repository
 from budget_forecaster.infrastructure.config import Config, EnableBankingConfig
+from budget_forecaster.infrastructure.db_lock import database_lock
 from budget_forecaster.web.auth import hash_password
 from budget_forecaster.web.config import ENV_SECRET_KEY
 
@@ -108,11 +109,16 @@ def _run_sync(config_path: Path) -> None:
     consent_service = _consent_service(config)
     swile_token_store = _swile_token_store(config)
 
-    repository = open_repository(config)
-    try:
-        runs = sync_all_sources(repository, config, consent_service, swile_token_store)
-    finally:
-        repository.close()
+    # Hold the lock for the whole session so a web-app restore cannot swap the
+    # database file while this process has it open.
+    with database_lock(config.database_path):
+        repository = open_repository(config)
+        try:
+            runs = sync_all_sources(
+                repository, config, consent_service, swile_token_store
+            )
+        finally:
+            repository.close()
 
     _report_sync_runs(runs)
     if any(run.status is SyncRunStatus.FAILED for run in runs):

--- a/tests/infrastructure/test_backup.py
+++ b/tests/infrastructure/test_backup.py
@@ -2,12 +2,13 @@
 
 import os
 import time
+from datetime import datetime
 from pathlib import Path
 
 import pytest
 
 from budget_forecaster.exceptions import BackupError
-from budget_forecaster.infrastructure.backup import BackupService
+from budget_forecaster.infrastructure.backup import BackupInfo, BackupService
 from budget_forecaster.infrastructure.config import BackupConfig, Config
 
 
@@ -282,6 +283,190 @@ class TestBackupErrorHandling:
         finally:
             backup_dir.chmod(0o755)
             oldest.chmod(0o644)
+
+
+class TestSafetyBackups:
+    """Tests for pre-restore safety snapshots and their independent rotation."""
+
+    def test_safety_backup_uses_marker_name(self, service: BackupService) -> None:
+        """A safety backup is named with the prerestore marker."""
+        path = service.create_backup(safety=True)
+        assert path.stem.startswith("test_prerestore_")
+
+    def test_safety_and_automatic_rotate_independently(
+        self, temp_db: Path, backup_dir: Path
+    ) -> None:
+        """Safety snapshots rotate on their own counter, never evicting backups."""
+        service = BackupService(
+            database_path=temp_db,
+            backup_directory=backup_dir,
+            max_backups=3,
+            max_safety_backups=2,
+        )
+        base_time = 1_000_000_000.0
+        for i in range(4):
+            auto = backup_dir / f"test_2025-01-17_10000{i}.db"
+            auto.write_text(f"auto {i}")
+            os.utime(auto, (base_time + i, base_time + i))
+            safety = backup_dir / f"test_prerestore_2025-01-17_10000{i}.db"
+            safety.write_text(f"safety {i}")
+            os.utime(safety, (base_time + i, base_time + i))
+
+        deleted = service.rotate_backups()
+
+        remaining = {p.name for p in service.get_existing_backups()}
+        # 3 newest automatic kept, 2 newest safety kept
+        assert len([n for n in remaining if "prerestore" in n]) == 2
+        assert len([n for n in remaining if "prerestore" not in n]) == 3
+        assert len(deleted) == 3
+
+
+class TestGetBackups:
+    """Tests for the UI-facing backup listing."""
+
+    def test_lists_newest_first_with_metadata(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """get_backups returns metadata sorted newest first."""
+        auto = backup_dir / "test_2025-01-17_100000.db"
+        auto.write_text("auto")
+        safety = backup_dir / "test_prerestore_2025-01-18_100000.db"
+        safety.write_text("safety")
+
+        backups = service.get_backups()
+
+        assert [b.path for b in backups] == [safety, auto]
+        assert backups[0] == BackupInfo(
+            path=safety,
+            timestamp=datetime(2025, 1, 18, 10, 0, 0),
+            size_bytes=safety.stat().st_size,
+            is_safety_copy=True,
+        )
+        assert backups[1].is_safety_copy is False
+
+    def test_timestamp_falls_back_to_mtime(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """An unparseable name falls back to the file mtime."""
+        odd = backup_dir / "test_manual.db"
+        odd.write_text("x")
+        os.utime(odd, (1_000_000_000.0, 1_000_000_000.0))
+
+        (info,) = service.get_backups()
+
+        assert info.timestamp == datetime.fromtimestamp(1_000_000_000.0)
+
+
+class TestResolveBackup:
+    """Tests for filename validation."""
+
+    def test_resolves_existing_backup(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """A valid backup name resolves to its path."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("x")
+        assert service.resolve_backup("test_2025-01-17_100000.db") == backup
+
+    @pytest.mark.parametrize(
+        "name",
+        ["../test.db", "sub/test.db", "missing.db"],
+        ids=["parent", "subdir", "unknown"],
+    )
+    def test_rejects_invalid_names(self, service: BackupService, name: str) -> None:
+        """Path traversal and unknown names are rejected."""
+        with pytest.raises(BackupError):
+            service.resolve_backup(name)
+
+
+class TestDeleteBackup:
+    """Tests for deleting a single backup."""
+
+    def test_deletes_named_backup(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """The named backup is removed."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("x")
+
+        service.delete_backup("test_2025-01-17_100000.db")
+
+        assert not backup.exists()
+
+    def test_delete_allows_last_backup(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """Deleting the only remaining backup is allowed."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("x")
+
+        service.delete_backup(backup.name)
+
+        assert service.get_existing_backups() == []
+
+    def test_rejects_unknown_backup(self, service: BackupService) -> None:
+        """Deleting an unknown name raises."""
+        with pytest.raises(BackupError):
+            service.delete_backup("nope.db")
+
+
+class TestRestoreBackup:
+    """Tests for restoring a backup over the live database."""
+
+    def test_swaps_file_and_returns_snapshot(
+        self, service: BackupService, temp_db: Path, backup_dir: Path
+    ) -> None:
+        """The database is replaced by the backup and a safety snapshot returned."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        snapshot = service.restore_backup(backup.name, migrate=lambda _: None)
+
+        assert temp_db.read_text() == "restored content"
+        assert snapshot.stem.startswith("test_prerestore_")
+        assert snapshot.read_text() == "test database content"
+
+    def test_migrate_receives_scratch_copy(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """The migrate callback runs on a scratch copy before the swap."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+        seen: dict[str, str] = {}
+
+        def migrate(scratch: Path) -> None:
+            seen["content"] = scratch.read_text()
+
+        service.restore_backup(backup.name, migrate=migrate)
+
+        assert seen["content"] == "restored content"
+
+    def test_cleans_scratch_on_success(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """No scratch file is left behind after a restore."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        service.restore_backup(backup.name, migrate=lambda _: None)
+
+        assert not (backup_dir / ".restore-test.tmp").exists()
+
+    def test_failed_migration_leaves_db_untouched(
+        self, service: BackupService, temp_db: Path, backup_dir: Path
+    ) -> None:
+        """A migration failure aborts before the swap; the live DB is unchanged."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        def failing(_: Path) -> None:
+            raise BackupError("migration failed")
+
+        with pytest.raises(BackupError):
+            service.restore_backup(backup.name, migrate=failing)
+
+        assert temp_db.read_text() == "test database content"
+        assert not (backup_dir / ".restore-test.tmp").exists()
 
 
 class TestBackupConfigParsing:

--- a/tests/infrastructure/test_backup.py
+++ b/tests/infrastructure/test_backup.py
@@ -1,6 +1,7 @@
 """Tests for the BackupService and BackupConfig."""
 
 import os
+import sqlite3
 import time
 from datetime import datetime
 from pathlib import Path
@@ -256,17 +257,17 @@ class TestBackupErrorHandling:
     def test_rotate_backups_continues_on_individual_delete_failure(
         self, temp_db: Path, backup_dir: Path
     ) -> None:
-        """rotate_backups continues when a single file fails to delete."""
+        """rotate_backups deletes the rest when one entry cannot be removed."""
         base_time = 1000000000.0
-        for i in range(5):
+        # The oldest entry is a directory: unlinking it fails, so rotation must
+        # still delete the other over-limit backup.
+        oldest = backup_dir / "test_2025-01-17_100000.db"
+        oldest.mkdir()
+        os.utime(oldest, (base_time, base_time))
+        for i in range(1, 5):
             backup = backup_dir / f"test_2025-01-17_10000{i}.db"
             backup.write_text(f"backup {i}")
             os.utime(backup, (base_time + i, base_time + i))
-
-        # Make the oldest backup non-deletable
-        oldest = backup_dir / "test_2025-01-17_100000.db"
-        oldest.chmod(0o444)
-        backup_dir.chmod(0o555)
 
         service = BackupService(
             database_path=temp_db,
@@ -274,15 +275,11 @@ class TestBackupErrorHandling:
             max_backups=3,
         )
 
-        try:
-            deleted = service.rotate_backups()
+        deleted = service.rotate_backups()
 
-            # Should have attempted both deletions; some may fail
-            # The important thing is that it doesn't crash
-            assert isinstance(deleted, list)
-        finally:
-            backup_dir.chmod(0o755)
-            oldest.chmod(0o644)
+        remaining = service.get_existing_backups()
+        assert oldest in remaining  # directory deletion failed, still present
+        assert deleted == [backup_dir / "test_2025-01-17_100001.db"]
 
 
 class TestSafetyBackups:
@@ -467,6 +464,62 @@ class TestRestoreBackup:
 
         assert temp_db.read_text() == "test database content"
         assert not (backup_dir / ".restore-test.tmp").exists()
+
+    def test_wraps_non_backup_migration_error(
+        self, service: BackupService, backup_dir: Path
+    ) -> None:
+        """A migration error that is not a BackupError is wrapped as one."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        def failing(_: Path) -> None:
+            raise sqlite3.OperationalError("no such column")
+
+        with pytest.raises(BackupError):
+            service.restore_backup(backup.name, migrate=failing)
+
+    def test_safety_snapshots_stay_bounded_across_restores(
+        self, temp_db: Path, backup_dir: Path
+    ) -> None:
+        """Repeated restores never grow the safety-snapshot pool past its cap."""
+        service = BackupService(
+            database_path=temp_db,
+            backup_directory=backup_dir,
+            max_safety_backups=2,
+        )
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        for _ in range(5):
+            service.restore_backup(backup.name, migrate=lambda _: None)
+
+        safety = [b for b in service.get_backups() if b.is_safety_copy]
+        assert len(safety) == 2
+
+    def test_rejects_cross_device_backup_directory(
+        self,
+        service: BackupService,
+        backup_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A backup directory on another filesystem is refused before any swap."""
+        backup = backup_dir / "test_2025-01-17_100000.db"
+        backup.write_text("restored content")
+
+        real_stat = Path.stat
+
+        def fake_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+            result = real_stat(self, *args, **kwargs)
+            if self == backup_dir:
+                fields = list(result)
+                fields[2] = result.st_dev + 1  # st_dev is index 2
+                return os.stat_result(fields)
+            return result
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+
+        with pytest.raises(BackupError, match="same filesystem"):
+            service.restore_backup(backup.name, migrate=lambda _: None)
 
 
 class TestBackupConfigParsing:

--- a/tests/infrastructure/test_backup_preview.py
+++ b/tests/infrastructure/test_backup_preview.py
@@ -111,3 +111,11 @@ class TestPreviewBackup:
 
         with pytest.raises(BackupError):
             preview_backup(current, corrupt)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """A backup deleted before preview surfaces a clean error."""
+        current = tmp_path / "budget.db"
+        _make_db(current, balance=10.0, op_dates=[], version=7)
+
+        with pytest.raises(BackupError):
+            preview_backup(current, tmp_path / "gone.db")

--- a/tests/infrastructure/test_backup_preview.py
+++ b/tests/infrastructure/test_backup_preview.py
@@ -1,0 +1,113 @@
+"""Tests for the read-only backup preview."""
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from budget_forecaster.core.amount import Amount
+from budget_forecaster.exceptions import BackupError
+from budget_forecaster.infrastructure.backup_preview import (
+    BackupMetrics,
+    preview_backup,
+)
+
+
+def _make_db(
+    path: Path,
+    *,
+    balance: float,
+    op_dates: list[str],
+    version: int | None,
+    currency: str = "EUR",
+) -> None:
+    """Write a minimal database with the tables the preview reads."""
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE accounts (balance REAL, currency TEXT)")
+    conn.execute("CREATE TABLE operations (date TEXT)")
+    conn.execute(
+        "INSERT INTO accounts (balance, currency) VALUES (?, ?)", (balance, currency)
+    )
+    conn.executemany(
+        "INSERT INTO operations (date) VALUES (?)", [(d,) for d in op_dates]
+    )
+    if version is not None:
+        conn.execute("CREATE TABLE schema_version (version INTEGER)")
+        conn.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
+    conn.commit()
+    conn.close()
+
+
+class TestPreviewBackup:
+    """Tests for computing preview metrics."""
+
+    def test_reads_metrics_for_both_files(self, tmp_path: Path) -> None:
+        """Current and backup metrics are read side by side."""
+        current = tmp_path / "budget.db"
+        backup = tmp_path / "budget_2025-01-17_100000.db"
+        _make_db(
+            current, balance=1240.5, op_dates=["2026-07-27", "2026-07-28"], version=7
+        )
+        _make_db(backup, balance=1190.0, op_dates=["2026-07-27"], version=6)
+
+        preview = preview_backup(current, backup)
+
+        assert preview.current == BackupMetrics(
+            total_balance=Amount(1240.5, "EUR"),
+            operation_count=2,
+            latest_operation_date=date(2026, 7, 28),
+            schema_version=7,
+        )
+        assert preview.backup == BackupMetrics(
+            total_balance=Amount(1190.0, "EUR"),
+            operation_count=1,
+            latest_operation_date=date(2026, 7, 27),
+            schema_version=6,
+        )
+
+    def test_empty_database(self, tmp_path: Path) -> None:
+        """No accounts or operations yields a zero balance and no latest date."""
+        db = tmp_path / "budget.db"
+        _make_db(db, balance=0.0, op_dates=[], version=7)
+        # Remove the seeded account row to exercise the empty case.
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM accounts")
+        conn.commit()
+        conn.close()
+
+        metrics = preview_backup(db, db).backup
+
+        assert metrics == BackupMetrics(
+            total_balance=Amount(0.0, "EUR"),
+            operation_count=0,
+            latest_operation_date=None,
+            schema_version=7,
+        )
+
+    def test_missing_schema_version_table(self, tmp_path: Path) -> None:
+        """A backup without a schema_version table reports version 0."""
+        db = tmp_path / "budget.db"
+        _make_db(db, balance=10.0, op_dates=["2026-01-01"], version=None)
+
+        assert preview_backup(db, db).backup.schema_version == 0
+
+    def test_does_not_mutate_the_backup(self, tmp_path: Path) -> None:
+        """Preview opens read-only and leaves the file byte-identical."""
+        db = tmp_path / "budget.db"
+        _make_db(db, balance=10.0, op_dates=["2026-01-01"], version=7)
+        before = db.read_bytes()
+
+        preview_backup(db, db)
+
+        assert db.read_bytes() == before
+
+    def test_corrupt_file_raises(self, tmp_path: Path) -> None:
+        """A file that is not a database surfaces a clean error."""
+        current = tmp_path / "budget.db"
+        _make_db(current, balance=10.0, op_dates=[], version=7)
+        corrupt = tmp_path / "budget_bad.db"
+        corrupt.write_text("not a database")
+
+        with pytest.raises(BackupError):
+            preview_backup(current, corrupt)

--- a/tests/infrastructure/test_db_lock.py
+++ b/tests/infrastructure/test_db_lock.py
@@ -1,0 +1,47 @@
+"""Tests for the cross-process database lock."""
+
+import fcntl
+from pathlib import Path
+
+from budget_forecaster.infrastructure.db_lock import database_lock
+
+
+def _try_lock(path: Path) -> bool:
+    """Attempt a non-blocking exclusive lock via a separate open file description.
+
+    flock locks bind to the open file description, so a distinct open of the same
+    file conflicts with the held lock even from the same process.
+    """
+    with open(path, "w", encoding="utf-8") as handle:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(handle, fcntl.LOCK_UN)
+            return True
+        except BlockingIOError:
+            return False
+
+
+class TestDatabaseLock:
+    """Tests for mutual exclusion on the lock file."""
+
+    def test_excludes_others_while_held(self, tmp_path: Path) -> None:
+        """A second acquirer cannot take the lock while the block holds it."""
+        db_path = tmp_path / "budget.db"
+        lock_path = tmp_path / "budget.db.lock"
+        with database_lock(db_path):
+            assert _try_lock(lock_path) is False
+
+    def test_released_after_block(self, tmp_path: Path) -> None:
+        """The lock is free again once the block exits."""
+        db_path = tmp_path / "budget.db"
+        lock_path = tmp_path / "budget.db.lock"
+        with database_lock(db_path):
+            pass
+        assert _try_lock(lock_path) is True
+
+    def test_creates_missing_parent(self, tmp_path: Path) -> None:
+        """The lock directory is created if absent."""
+        db_path = tmp_path / "nested" / "budget.db"
+        with database_lock(db_path):
+            pass
+        assert (tmp_path / "nested" / "budget.db.lock").exists()


### PR DESCRIPTION
Part of #336 (PR1 of 2 — core infra, no UI yet).

## Summary

Extends BackupService with everything the web backup UI (PR2) will call, plus the reliability guards the design review surfaced.

- **Restore** (`restore_backup`): takes a pre-restore safety snapshot, copies the chosen backup to a scratch file, migrates it to the current schema, then atomically `os.replace`s it into place. Migration is injected as a callback so the service stays file-ops only and doesn't depend on the persistence layer. A backup that predates a migration is upgraded before the swap, so an older backup can't leave the live DB on a broken schema.
- **Cross-process lock** (`db_lock.database_lock`): advisory `flock` on a lock file next to the DB. The restore holds it during the swap and the sync command holds it for its whole session, so a scheduled sync can't write into the file being replaced (which would silently lose those writes).
- **Safety-snapshot rotation**: pre-restore snapshots rotate on their own counter (keep last 3) instead of being exempt forever, so repeated restore/undo cycles can't grow the backup directory without bound.
- **Read-only preview** (`preview_backup`): reads lightweight metrics (balance, operation count, latest date, schema version) straight from the backup on a read-only connection, without touching the live connection or running migrations. Robust to older-schema backups.
- **List / delete / resolve**: `get_backups` returns UI metadata newest-first with a safety-copy flag; `resolve_backup`/`delete_backup` validate the filename against the backup directory (no path traversal), and deleting the last backup is allowed.

## Test plan

- `tests/infrastructure/test_backup.py`: safety naming, independent rotation counters, listing metadata + mtime fallback, filename validation (traversal/unknown), delete (incl. last), restore (file swap, migrate runs on scratch, scratch cleanup, failed migration leaves the DB untouched).
- `tests/infrastructure/test_db_lock.py`: exclusion while held, release after the block, parent creation.
- `tests/infrastructure/test_backup_preview.py`: metrics for both files, empty DB, missing schema_version table, no mutation (read-only), corrupt file raises.
- Full suite: 1065 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)