### PR TITLE
fix: stop listing overdue payments nobody will act on

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -85,6 +85,7 @@ hh
 historicoperation
 honour
 honoured
+honouring
 honours
 http
 hx

--- a/budget_forecaster/services/application_service.py
+++ b/budget_forecaster/services/application_service.py
@@ -45,6 +45,7 @@ from budget_forecaster.services.forecast.forecast_service import (
     MonthlySummary,
 )
 from budget_forecaster.services.forecast.iteration_lifecycle import (
+    OVERDUE_LISTING_WINDOW,
     derive_past_iterations,
     index_resolutions,
 )
@@ -195,10 +196,6 @@ def _has_iteration(op: PlannedOperation, iteration_date: date) -> bool:
         if date_range.start_date > iteration_date:
             return False
     return False
-
-
-OVERDUE_LISTING_WINDOW = relativedelta(months=6)
-"""How far back the overdue list reaches, well past the late horizon."""
 
 
 class OverdueIteration(NamedTuple):
@@ -474,12 +471,15 @@ class ApplicationService:  # pylint: disable=too-many-instance-attributes,too-ma
         Postponed and skipped iterations are left out: the user already decided,
         and their decision is listed on the planned operation itself.
 
-        The list reaches back OVERDUE_LISTING_WINDOW, so an operation backdated by
-        years does not bury the card under iterations that left the forecast long
-        ago. Anything older stopped being counted at the late horizon.
+        The list reaches back OVERDUE_LISTING_WINDOW. Anything older left the
+        forecast a month before that, and a month of not acting on it says enough.
+
+        The window is checked per occurrence, not only through the derivation's own
+        bound: a stored decision widens that bound so old decisions keep being
+        honoured, and one such decision must not drag the undecided tail back in.
         """
         balance_date = self.balance_date
-        since = balance_date - OVERDUE_LISTING_WINDOW
+        listing_start = balance_date - OVERDUE_LISTING_WINDOW
         linked = self._linked_iterations_by_planned_operation()
         resolutions = index_resolutions(
             self._iteration_resolution_service.get_all_resolutions()
@@ -494,11 +494,14 @@ class ApplicationService:  # pylint: disable=too-many-instance-attributes,too-ma
                 balance_date,
                 linked.get(op.id, set()),
                 resolutions.get(op.id, {}),
-                since=since,
+                since=listing_start,
             ):
                 if past.state not in (IterationState.LATE, IterationState.EXPIRED):
                     continue
-                reference = past.postponed_to or past.iteration_date
+                if (
+                    reference := past.postponed_to or past.iteration_date
+                ) < listing_start:
+                    continue
                 overdue.append(
                     OverdueIteration(
                         planned_operation_id=past.planned_operation_id,

--- a/budget_forecaster/services/forecast/iteration_lifecycle.py
+++ b/budget_forecaster/services/forecast/iteration_lifecycle.py
@@ -24,7 +24,14 @@ LATE_HORIZON: Final = timedelta(days=31)
 """How long an unmatched iteration keeps weighing on the forecast.
 
 Undecided iterations older than this stop being counted, and say so in the
-overdue list: dropping them silently is what this lifecycle exists to prevent.
+overdue list rather than dropping out of it.
+"""
+
+OVERDUE_LISTING_WINDOW: Final = 2 * LATE_HORIZON
+"""How far back the overdue list reaches.
+
+One late horizon to be counted, one more to be noticed. An iteration nobody acted
+on by then leaves the list; a decision taken on it is still honoured.
 """
 
 

--- a/budget_forecaster/web/routes/overdue.py
+++ b/budget_forecaster/web/routes/overdue.py
@@ -412,7 +412,8 @@ async def restore(
         None,
     )
     if row is None:
-        # Nothing to put back: a link settled the iteration meanwhile.
+        # Nothing to put back: a link settled the iteration meanwhile, or it aged
+        # past the listing window while the decision held it out of the card.
         return render_template(
             request, "fragments/overdue_gone.html", active="home", **context
         )

--- a/docs/user/web-app.md
+++ b/docs/user/web-app.md
@@ -78,8 +78,12 @@ list, with a count on the Accueil tab so you see it from any page.
 
 Each overdue row says how late the payment is and whether the forecast still counts it:
 for a month it does, on the day after your balance date, then it stops being counted and
-the row says so. Either way it stays listed until you settle it — nothing is dropped
-behind your back.
+the row says so. It stays listed a second month, which is there for you to notice it,
+and then the row leaves the card, taking its two decisions with it — by that point the
+amount has been out of the forecast for a month, so there is nothing left to settle. A
+decision you took while the row was there is kept for good, so a postponement made in
+time still moves the amount long after. Linking the payment stays possible whenever you
+find it, from the operation's own row in Opérations.
 
 **Lier…** is the first thing to try, and the description opens the same page. Most often
 the payment did happen and the matcher did not recognize it, so the page lists the

--- a/tests/services/forecast/test_forecast_actualizer.py
+++ b/tests/services/forecast/test_forecast_actualizer.py
@@ -11,11 +11,12 @@ from budget_forecaster.core.date_range import (
     RecurringDay,
     SingleDay,
 )
-from budget_forecaster.core.types import Category, LinkType
+from budget_forecaster.core.types import Category, IterationAction, LinkType
 from budget_forecaster.domain.account.account import Account
 from budget_forecaster.domain.forecast.forecast import Forecast
 from budget_forecaster.domain.operation.budget import Budget
 from budget_forecaster.domain.operation.historic_operation import HistoricOperation
+from budget_forecaster.domain.operation.iteration_resolution import IterationResolution
 from budget_forecaster.domain.operation.operation_link import OperationLink
 from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.services.forecast.forecast_actualizer import ForecastActualizer
@@ -85,7 +86,8 @@ class TestForecastActualizer:
     ) -> None:
         """Past the late horizon an undecided iteration leaves the forecast.
 
-        It is still reported as overdue, so the money does not vanish unnoticed.
+        It is still reported as overdue for another month, so the money does not
+        vanish unnoticed.
         """
         forecast = Forecast(
             operations=(
@@ -102,6 +104,41 @@ class TestForecastActualizer:
         actualizer = ForecastActualizer(account)
         actualized_forecast = actualizer(forecast)
         assert not actualized_forecast.operations
+
+    def test_a_decision_older_than_any_listing_window_is_still_applied(
+        self, account: Account
+    ) -> None:
+        """A postponement holds however old the iteration it was taken on."""
+        forecast = Forecast(
+            operations=(
+                PlannedOperation(
+                    record_id=1,
+                    description="Postponed Long Ago",
+                    amount=Amount(50.0, "EUR"),
+                    category=Category.GROCERIES,
+                    date_range=SingleDay(date(2022, 6, 5)),
+                ),
+            ),
+            budgets=(),
+        )
+        actualizer = ForecastActualizer(
+            account,
+            iteration_resolutions=(
+                IterationResolution(
+                    planned_operation_id=1,
+                    iteration_date=date(2022, 6, 5),
+                    action=IterationAction.POSTPONE,
+                    postponed_to=date(2023, 2, 5),
+                ),
+            ),
+        )
+
+        actualized_forecast = actualizer(forecast)
+
+        assert len(actualized_forecast.operations) == 1
+        assert actualized_forecast.operations[0].date_range.start_date == date(
+            2023, 2, 5
+        )
 
     def test_one_time_operation_on_balance_date_is_postponed(
         self, account: Account

--- a/tests/services/forecast/test_iteration_lifecycle.py
+++ b/tests/services/forecast/test_iteration_lifecycle.py
@@ -11,6 +11,7 @@ from budget_forecaster.domain.operation.iteration_resolution import IterationRes
 from budget_forecaster.domain.operation.planned_operation import PlannedOperation
 from budget_forecaster.services.forecast.iteration_lifecycle import (
     LATE_HORIZON,
+    OVERDUE_LISTING_WINDOW,
     derive_past_iterations,
     index_resolutions,
 )
@@ -43,6 +44,11 @@ def _one_time(iteration: date) -> PlannedOperation:
 def test_the_late_horizon_is_a_month() -> None:
     """The documented value, pinned: the user docs and the design both say a month."""
     assert LATE_HORIZON == timedelta(days=31)
+
+
+def test_the_listing_window_is_two_late_horizons() -> None:
+    """A month counted, a month to notice: what the user docs promise."""
+    assert OVERDUE_LISTING_WINDOW == timedelta(days=62)
 
 
 class TestUndecidedIterations:

--- a/tests/services/test_application_service.py
+++ b/tests/services/test_application_service.py
@@ -32,7 +32,10 @@ from budget_forecaster.exceptions import (
     OperationNotFoundError,
     PlannedOperationNotFoundError,
 )
-from budget_forecaster.services.application_service import ApplicationService
+from budget_forecaster.services.application_service import (
+    ApplicationService,
+    OverdueIteration,
+)
 from budget_forecaster.services.forecast.forecast_service import ForecastService
 from budget_forecaster.services.import_service import ImportResult, ImportService
 from budget_forecaster.services.operation.iteration_resolution_service import (
@@ -1399,7 +1402,7 @@ class TestOverdueIterations:
                 description="Insurance",
                 amount=Amount(-145.0, "EUR"),
                 category=Category.HOUSE_INSURANCE,
-                date_range=SingleDay(date(2025, 1, 10)),
+                date_range=SingleDay(date(2025, 2, 10)),
             )
         ]
 
@@ -1507,6 +1510,118 @@ class TestOverdueIterations:
         assert overdue.iteration_date == date(2025, 3, 5)
         assert overdue.postponed_to == date(2025, 3, 15)
         assert overdue.days_overdue == 5
+
+    @pytest.mark.parametrize(
+        "iteration_date,expected",
+        [
+            (
+                date(2025, 1, 17),
+                (
+                    OverdueIteration(
+                        planned_operation_id=7,
+                        iteration_date=date(2025, 1, 17),
+                        description="Insurance",
+                        amount=-145.0,
+                        currency="EUR",
+                        state=IterationState.EXPIRED,
+                        days_overdue=62,
+                        counted_on=None,
+                    ),
+                ),
+            ),
+            (date(2025, 1, 16), ()),
+        ],
+        ids=["oldest_listed_day", "one_day_too_old"],
+    )
+    def test_the_listing_window_bounds_what_the_card_shows(
+        self,
+        app_service: ApplicationService,
+        mock_forecast_service: MagicMock,
+        iteration_date: date,
+        expected: tuple[OverdueIteration, ...],
+    ) -> None:
+        """Listed for a month past the late horizon, then gone."""
+        mock_forecast_service.get_all_planned_operations.return_value = [
+            PlannedOperation(
+                record_id=7,
+                description="Insurance",
+                amount=Amount(-145.0, "EUR"),
+                category=Category.HOUSE_INSURANCE,
+                date_range=SingleDay(iteration_date),
+            )
+        ]
+
+        assert app_service.get_overdue_iterations() == expected
+
+    def test_an_old_decision_does_not_bring_back_the_undecided_tail(
+        self,
+        app_service: ApplicationService,
+        mock_forecast_service: MagicMock,
+        mock_iteration_resolution_service: MagicMock,
+    ) -> None:
+        """Honouring an old decision must not widen what the card lists."""
+        mock_forecast_service.get_all_planned_operations.return_value = [
+            PlannedOperation(
+                record_id=7,
+                description="Rent",
+                amount=Amount(-850.0, "EUR"),
+                category=Category.RENT,
+                date_range=RecurringDay(date(2024, 9, 5), relativedelta(months=1)),
+            )
+        ]
+        mock_iteration_resolution_service.get_all_resolutions.return_value = (
+            IterationResolution(
+                planned_operation_id=7,
+                iteration_date=date(2024, 9, 5),
+                action=IterationAction.SKIP,
+            ),
+        )
+
+        result = app_service.get_overdue_iterations()
+
+        assert [it.iteration_date for it in result] == [
+            date(2025, 2, 5),
+            date(2025, 3, 5),
+        ]
+
+    def test_an_old_iteration_postponed_into_the_window_stays_listed(
+        self,
+        app_service: ApplicationService,
+        mock_forecast_service: MagicMock,
+        mock_iteration_resolution_service: MagicMock,
+    ) -> None:
+        """The window measures the date the user chose, not the original."""
+        mock_forecast_service.get_all_planned_operations.return_value = [
+            PlannedOperation(
+                record_id=7,
+                description="Insurance",
+                amount=Amount(-145.0, "EUR"),
+                category=Category.HOUSE_INSURANCE,
+                date_range=SingleDay(date(2024, 11, 5)),
+            )
+        ]
+        mock_iteration_resolution_service.get_all_resolutions.return_value = (
+            IterationResolution(
+                planned_operation_id=7,
+                iteration_date=date(2024, 11, 5),
+                action=IterationAction.POSTPONE,
+                postponed_to=date(2025, 3, 10),
+            ),
+        )
+
+        assert app_service.get_overdue_iterations() == (
+            OverdueIteration(
+                planned_operation_id=7,
+                iteration_date=date(2024, 11, 5),
+                description="Insurance",
+                amount=-145.0,
+                currency="EUR",
+                state=IterationState.LATE,
+                days_overdue=10,
+                counted_on=date(2025, 3, 21),
+                postponed_to=date(2025, 3, 10),
+            ),
+        )
 
 
 class TestIterationDecisions:

--- a/tests/web/test_overdue.py
+++ b/tests/web/test_overdue.py
@@ -26,9 +26,14 @@ class Overdue(NamedTuple):
 
 
 def _create_unmatched(
-    client: TestClient, app: FastAPI, *, days_before_balance: int, amount: str
+    client: TestClient,
+    app: FastAPI,
+    *,
+    days_before_balance: int,
+    amount: str,
+    recurring: bool = True,
 ) -> Overdue:
-    """Create a monthly payment whose iterations nothing will ever match."""
+    """Create a payment whose iterations nothing will ever match."""
     iteration = app.state.app_service.balance_date - timedelta(days=days_before_balance)
     client.post(
         "/targets/planned",
@@ -37,7 +42,7 @@ def _create_unmatched(
             "amount": amount,
             "category": "RENT",
             "start_date": iteration.isoformat(),
-            "recurring": "yes",
+            "recurring": "yes" if recurring else "no",
             "period_value": "1",
             "period_unit": "months",
             "end_date": "",
@@ -48,7 +53,8 @@ def _create_unmatched(
         },
         follow_redirects=False,
     )
-    listing = client.get("/targets?view=planned").text
+    # Past one-time payments are inactive, which the listing hides by default.
+    listing = client.get("/targets?view=planned&submitted=1&active=false").text
     row = listing[listing.find(_DESCRIPTION) - 400 : listing.find(_DESCRIPTION)]
     found = re.findall(r"/targets/planned/(\d+)", row)
     assert found, "the new planned operation should be listed"
@@ -391,6 +397,49 @@ class TestUncountedIteration:
         card = _card(client)
 
         assert f"/overdue/{overdue.op_id}/{overdue.iteration}/postpone" in card
+
+
+class TestListingWindow:
+    """The card stops one late horizon past the one that stopped counting."""
+
+    def test_an_iteration_inside_the_window_is_listed(
+        self, client: TestClient, app: FastAPI
+    ) -> None:
+        """The last day of the window still asks for a decision."""
+        _create_unmatched(
+            client, app, days_before_balance=62, amount="-321", recurring=False
+        )
+
+        assert _DESCRIPTION in _card(client)
+
+    def test_an_iteration_past_the_window_is_gone(
+        self, client: TestClient, app: FastAPI
+    ) -> None:
+        """One day later nobody will act on it: it leaves the card and the badge."""
+        before = _card(client).count('class="overdue-item"')
+
+        _create_unmatched(
+            client, app, days_before_balance=63, amount="-321", recurring=False
+        )
+
+        card = _card(client)
+        assert _DESCRIPTION not in card
+        assert card.count('class="overdue-item"') == before
+
+    def test_its_actions_go_with_it(self, client: TestClient, app: FastAPI) -> None:
+        """No route acts on a row the card no longer offers."""
+        gone = _create_unmatched(
+            client, app, days_before_balance=63, amount="-321", recurring=False
+        )
+
+        assert (
+            client.get(f"/overdue/{gone.op_id}/{gone.iteration}/link").status_code
+            == 404
+        )
+        assert (
+            client.post(f"/overdue/{gone.op_id}/{gone.iteration}/skip").status_code
+            == 404
+        )
 
 
 class TestUnknownIterations:


### PR DESCRIPTION
## What changes

The overdue card reached back six months, well past the 31-day horizon where an unmatched occurrence leaves the forecast. On a real database that tail is noise: a month of not acting on a payment that stopped being counted is itself an answer.

| Before | After |
|---|---|
| Listed for 6 months | Listed for 62 days, derived as `2 * LATE_HORIZON` |
| Constant sat in the application service | Sits next to `LATE_HORIZON` in the iteration lifecycle |

The window is checked **per occurrence**, not only through the derivation's `since` bound. That bound is deliberately widened to `min(since, *resolutions)` so a stored decision keeps being honoured however old it is — which means one old decision would otherwise drag an operation's whole undecided tail back into the card. An occurrence postponed from outside the window into it is measured on the date the user chose, so it stays listed.

Nothing changes numerically: only `EXPIRED` occurrences can fall out of the list, and those already carried no amount. A decision taken while the row was there still applies, including a postponement that moves the amount long after the row is gone.

## Test plan

- `OVERDUE_LISTING_WINDOW` pinned at 62 days, next to the existing pin on the late horizon
- window boundary parametrized at 62 and 63 days, asserting the whole `OverdueIteration`
- an old decision does not bring back the undecided tail (fails without the per-occurrence check)
- an old occurrence postponed into the window stays listed, measured on the chosen date
- a decision older than any listing window still moves the amount in the actualizer
- web-level: 62 days listed, 63 days absent from the card, and its `/overdue/...` routes 404 (both fail with the old six-month window)
- full suite: 1251 passed; pre-commit clean

## Documentation

The web app guide now states both durations, that the row's two decisions leave with it, and that linking the payment stays possible from the operations ledger.

## Note

`docs/user/forecast.md` still describes the iteration states as they were before the lifecycle work (no `EXPIRED`/`SKIPPED`, and "Postponed = late beyond tolerance threshold" is wrong). Pre-existing and left alone here; tracked separately.

Closes #345