### PR TITLE
refactor: base the stylesheet on design tokens

### DIFF
--- a/.custom.dic
+++ b/.custom.dic
@@ -134,6 +134,7 @@ opérations
 orchestrator
 os
 overridable
+paddings
 params
 paribas
 parseable
@@ -176,6 +177,7 @@ sparkline
 startswith
 stderr
 str
+stylesheet
 subclasses
 subcommand
 submodules

--- a/.custom.dic
+++ b/.custom.dic
@@ -206,6 +206,7 @@ unconfigured
 unconsented
 unforecasted
 unicode
+unitless
 unlink
 unlinked
 unlinking

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -25,6 +25,7 @@
   --warn-text: #7a5b00;
   --good-bg: #e2f4e8;
   --good-text: #14663a;
+  --neutral-bg: #eef0f3;
 
   /* --- Type: eight steps, every literal snapped to the nearest one --- */
   --fs-2xs: 0.72rem;
@@ -73,6 +74,8 @@
   --axis-gutter: 4.5rem;
   /* Touch target floor. */
   --control-min-h: 44px;
+  /* Donut legend swatch; the sub-list indent aligns under it. */
+  --swatch-w: 0.8rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -95,6 +98,7 @@
     --warn-text: #f0d78a;
     --good-bg: #123524;
     --good-text: #7fd6a2;
+    --neutral-bg: #22252b;
     --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     /* 0.12 alpha is invisible on --surface; the bar needs a real one. */
     --shadow-up: 0 -2px 6px rgba(0, 0, 0, 0.5);
@@ -111,6 +115,7 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.4;
+  font-variant-numeric: tabular-nums;
 }
 
 a {
@@ -120,7 +125,7 @@ a {
 
 :focus-visible {
   outline: var(--focus-ring);
-  outline-offset: 2px;
+  outline-offset: var(--sp-2);
 }
 
 .brand {
@@ -208,7 +213,7 @@ a {
   color: var(--good-text);
 }
 .banner-cancelled {
-  background: var(--surface-alt);
+  background: var(--neutral-bg);
   color: var(--muted);
 }
 /* --- Cards --- */
@@ -546,7 +551,7 @@ table {
   gap: var(--sp-8);
   margin-bottom: var(--sp-12);
 }
-.filters input,
+.filters input:not([type='checkbox']),
 .filters select {
   min-height: var(--control-min-h);
   padding: var(--sp-6) var(--sp-8);
@@ -601,14 +606,8 @@ a.link-tag {
 a.link-tag:hover,
 a.link-tag:focus-visible {
   background: var(--accent);
-  color: var(--text-inverse);
+  color: var(--on-accent);
   text-decoration: underline;
-}
-a.link-tag:focus-visible,
-a.overdue-edit:focus-visible,
-.link-action:focus-visible {
-  outline: var(--focus-ring);
-  outline-offset: 2px;
 }
 
 /* --- Trends: balance curve --- */
@@ -804,8 +803,8 @@ a.overdue-edit:focus-visible,
   font-size: var(--fs-sm);
 }
 .donut-legend .swatch {
-  width: 0.8rem;
-  height: 0.8rem;
+  width: var(--swatch-w);
+  height: var(--swatch-w);
   border-radius: var(--radius-2xs);
   flex: 0 0 auto;
 }
@@ -827,7 +826,7 @@ a.overdue-edit:focus-visible,
   list-style: none;
   margin: 0;
   /* Indent aligns the sub-list under the label: swatch width + gap. */
-  padding: var(--sp-2) 0 var(--sp-4) calc(0.8rem + var(--sp-8));
+  padding: var(--sp-2) 0 var(--sp-4) calc(var(--swatch-w) + var(--sp-8));
 }
 .donut-legend .legend-members li {
   border-bottom: none;
@@ -1215,7 +1214,6 @@ a.overdue-edit:focus-visible,
   /* A nav row is flex: without this the count is what gets squeezed, and a
      two-digit badge loses its second digit. */
   flex-shrink: 0;
-  min-width: 1.1rem;
   margin-left: var(--sp-6);
   padding: var(--sp-4) var(--sp-6);
   font-size: var(--fs-2xs);

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -2,33 +2,102 @@
    Mobile-first: bottom nav bar; a left sidebar takes over on wide screens. */
 
 :root {
+  /* --- Colour --- */
   --bg: #f5f6f8;
   --surface: #ffffff;
+  /* A recessed area inside a card: bar tracks, pills, inset panels. */
+  --surface-alt: #f5f6f8;
+  --surface-hover: #f5f6f8;
   --text: #1c1f26;
+  /* Text on a --text background: tooltips invert. */
+  --text-inverse: #f5f6f8;
+  /* Text on an --accent background. */
+  --on-accent: #ffffff;
   --muted: #6b7280;
   --border: #e3e6ea;
   --accent: #2f6df6;
   --good: #1f9d55;
   --bad: #d64545;
   --warn: #c77700;
-  --income: #1f9d55;
+  --error-bg: #fbe0e0;
+  --error-text: #7a1616;
+  --warn-bg: #fff3cd;
+  --warn-text: #7a5b00;
+  --good-bg: #e2f4e8;
+  --good-text: #14663a;
+
+  /* --- Type: eight steps, every literal snapped to the nearest one --- */
+  --fs-2xs: 0.72rem;
+  --fs-xs: 0.8rem;
+  --fs-sm: 0.875rem;
+  --fs-base: 1rem;
+  --fs-md: 1.2rem;
+  --fs-lg: 1.5rem;
+  --fs-xl: 2rem;
+  --fs-2xl: 2.75rem;
+
+  /* --- Spacing: a 2px grid, named by value, so a snap never moves >1px.
+     Exempt and deliberately literal: derived geometry (a negative half-width,
+     an indent that equals swatch + gap), positional nudges, and media-query
+     lengths, where var() does not work. --- */
+  --sp-2: 2px;
+  --sp-4: 4px;
+  --sp-6: 6px;
+  --sp-8: 8px;
+  --sp-10: 10px;
+  --sp-12: 12px;
+  --sp-14: 14px;
+  --sp-16: 16px;
+  --sp-24: 24px;
+  --sp-32: 32px;
+
+  /* --- Radii --- */
+  --radius-2xs: 2px;
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  /* --- Elevation and focus --- */
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-up: 0 -2px 6px rgba(0, 0, 0, 0.12);
+  --focus-ring: 2px solid var(--accent);
+
+  /* --- Layout --- */
   --nav-h: 56px;
+  --sidebar-w: 200px;
+  --content-max: 900px;
+  --content-max-wide: 1500px;
+  /* Chart y-axis gutter: the label column and the plot padding must agree. */
+  --axis-gutter: 4.5rem;
+  /* Touch target floor. */
+  --control-min-h: 44px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #14161a;
     --surface: #1e2127;
+    --surface-alt: #14161a;
+    --surface-hover: #14161a;
     --text: #e6e8ec;
+    --text-inverse: #14161a;
     --muted: #9aa1ac;
     --border: #2c313a;
     --accent: #5b8dff;
     --good: #3fce7c;
     --bad: #f0736f;
     --warn: #e0a83e;
-    --income: #3fce7c;
+    --error-bg: #3a1a1a;
+    --error-text: #f0a8a4;
+    --warn-bg: #3a2f0a;
+    --warn-text: #f0d78a;
+    --good-bg: #123524;
+    --good-text: #7fd6a2;
     --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    /* 0.12 alpha is invisible on --surface; the bar needs a real one. */
+    --shadow-up: 0 -2px 6px rgba(0, 0, 0, 0.5);
   }
 }
 
@@ -49,10 +118,15 @@ a {
   text-decoration: none;
 }
 
+:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .brand {
   font-weight: 700;
-  font-size: 1.1rem;
-  padding: 0.5rem 0;
+  font-size: var(--fs-md);
+  padding: var(--sp-8) 0;
 }
 
 /* --- Navigation --- */
@@ -79,19 +153,20 @@ a {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  font-size: 0.68rem;
+  gap: var(--sp-2);
+  font-size: var(--fs-2xs);
   color: var(--muted);
   text-align: center;
 }
 .nav-icon {
-  font-size: 1.15rem;
+  font-size: var(--fs-md);
   line-height: 1;
 }
 .bottombar .badge {
   position: absolute;
   top: 3px;
   left: 50%;
+  /* Nudge off the centre line, not spacing. */
   margin-left: 0.4rem;
 }
 
@@ -101,69 +176,48 @@ a {
 }
 
 .content {
-  padding: 1rem;
-  padding-bottom: calc(var(--nav-h) + 1rem);
-  max-width: 900px;
+  padding: var(--sp-16);
+  padding-bottom: calc(var(--nav-h) + var(--sp-16));
+  max-width: var(--content-max);
   margin: 0 auto;
 }
 
 /* --- Banner --- */
 .banner {
-  border-radius: 8px;
-  padding: 0.7rem 1rem;
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
+  border-radius: var(--radius-md);
+  padding: var(--sp-12) var(--sp-16);
+  margin-bottom: var(--sp-16);
+  font-size: var(--fs-sm);
 }
 .banner a {
-  margin-left: 0.5rem;
+  margin-left: var(--sp-8);
   font-weight: 600;
 }
 .banner-expiring {
-  background: #fff3cd;
-  color: #7a5b00;
+  background: var(--warn-bg);
+  color: var(--warn-text);
 }
 .banner-expired,
 .banner-failed,
 .banner-error {
-  background: #fbe0e0;
-  color: #7a1616;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 .banner-linked {
-  background: #e2f4e8;
-  color: #14663a;
+  background: var(--good-bg);
+  color: var(--good-text);
 }
 .banner-cancelled {
-  background: var(--surface-alt, #eef0f3);
+  background: var(--surface-alt);
   color: var(--muted);
 }
-@media (prefers-color-scheme: dark) {
-  .banner-expiring {
-    background: #3a2f0a;
-    color: #f0d78a;
-  }
-  .banner-expired,
-  .banner-failed,
-  .banner-error {
-    background: #3a1a1a;
-    color: #f0a8a4;
-  }
-  .banner-linked {
-    background: #123524;
-    color: #7fd6a2;
-  }
-  .banner-cancelled {
-    background: #22252b;
-    color: var(--muted);
-  }
-}
-
 /* --- Cards --- */
 .card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1rem;
-  margin-bottom: 1rem;
+  border-radius: var(--radius-lg);
+  padding: var(--sp-16);
+  margin-bottom: var(--sp-16);
   box-shadow: var(--shadow);
 }
 .card-head {
@@ -172,12 +226,12 @@ a {
   justify-content: space-between;
 }
 .card-head h2 {
-  font-size: 1rem;
-  margin: 0 0 0.5rem;
+  font-size: var(--fs-base);
+  margin: 0 0 var(--sp-8);
 }
 .card-link {
   display: inline-block;
-  margin-top: 0.5rem;
+  margin-top: var(--sp-8);
   font-weight: 600;
 }
 
@@ -190,7 +244,7 @@ a {
   color: var(--good);
 }
 .margin-warn .metric-value {
-  color: #b8860b;
+  color: var(--warn);
 }
 .margin-bad .metric-value {
   color: var(--bad);
@@ -201,27 +255,27 @@ a {
 }
 .metric-label {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .metric-value {
-  font-size: 2rem;
+  font-size: var(--fs-xl);
   font-weight: 700;
-  margin: 0.2rem 0;
+  margin: var(--sp-4) 0;
 }
 .metric-value.big {
-  font-size: 2.8rem;
+  font-size: var(--fs-2xl);
 }
 .metric-sub {
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: var(--fs-sm);
 }
 
 /* Balance is the headline number; the two secondary stats sit below it. */
 .stat-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: var(--sp-16);
+  margin-bottom: var(--sp-16);
 }
 .stat {
   flex: 1;
@@ -230,7 +284,7 @@ a {
   text-align: center;
 }
 .stat .metric-value {
-  font-size: 1.6rem;
+  font-size: var(--fs-lg);
 }
 .stat-link {
   color: inherit;
@@ -242,15 +296,15 @@ a {
 .info {
   cursor: help;
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
 }
 
 .pill {
-  background: var(--bg);
+  background: var(--surface-alt);
   border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 0.1rem 0.6rem;
-  font-size: 0.85rem;
+  border-radius: var(--radius-pill);
+  padding: var(--sp-2) var(--sp-10);
+  font-size: var(--fs-sm);
   font-weight: 600;
 }
 
@@ -258,8 +312,8 @@ a {
 .overall-bar {
   position: relative;
   height: 1.5rem;
-  background: var(--bg);
-  border-radius: 8px;
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -279,41 +333,42 @@ a {
 .overall-pct {
   position: relative;
   margin-left: auto;
-  padding: 0 0.6rem;
+  padding: 0 var(--sp-10);
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .subhead {
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
   color: var(--muted);
-  margin: 0.9rem 0 0.3rem;
+  margin: var(--sp-14) 0 var(--sp-4);
 }
 
 /* Readable Actual/Planned columns on the home month summary. */
 .mini {
-  font-size: 0.9rem;
-  margin-bottom: 0.5rem;
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-8);
 }
 .mini th {
   color: var(--muted);
-  font-weight: 500;
-  font-size: 0.8rem;
+  font-weight: 600;
+  font-size: var(--fs-xs);
   text-align: left;
-  padding: 0.2rem 0.4rem;
+  padding: var(--sp-4) var(--sp-6);
   border-bottom: 1px solid var(--border);
 }
 .mini th.num {
   text-align: right;
 }
 .mini td {
-  padding: 0.3rem 0.4rem;
+  padding: var(--sp-4) var(--sp-6);
   border-bottom: 1px solid var(--border);
 }
 .more-btn {
-  margin-top: 0.6rem;
-  padding: 0.4rem 0.9rem;
+  margin-top: var(--sp-10);
+  min-height: var(--control-min-h);
+  padding: var(--sp-6) var(--sp-14);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--accent);
   font-weight: 600;
@@ -332,13 +387,12 @@ a {
 .upcoming-list li {
   display: flex;
   justify-content: space-between;
-  padding: 0.35rem 0;
+  padding: var(--sp-6) 0;
   border-bottom: 1px solid var(--border);
 }
 .cat-figures,
 .up-amount {
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
 }
 .up-date {
   color: var(--muted);
@@ -346,11 +400,11 @@ a {
 }
 .up-note {
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
 }
 .up-desc {
   flex: 1;
-  padding: 0 0.5rem;
+  padding: 0 var(--sp-8);
 }
 /* A name that happens to be navigable reads as content, not as a URL. */
 .up-desc a,
@@ -380,15 +434,15 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  margin-bottom: var(--sp-16);
 }
 .month-nav h1 {
-  font-size: 1.2rem;
+  font-size: var(--fs-md);
   margin: 0;
 }
 .month-nav a {
-  font-size: 1.5rem;
-  padding: 0 0.8rem;
+  font-size: var(--fs-lg);
+  padding: 0 var(--sp-12);
 }
 
 /* --- Tables --- */
@@ -398,13 +452,13 @@ table {
 }
 .review,
 .ledger {
-  font-size: 0.9rem;
+  font-size: var(--fs-sm);
 }
 .review th,
 .review td,
 .ledger th,
 .ledger td {
-  padding: 0.4rem 0.5rem;
+  padding: var(--sp-6) var(--sp-8);
   border-bottom: 1px solid var(--border);
   text-align: left;
 }
@@ -415,7 +469,6 @@ table {
 .ledger td.num,
 .num {
   text-align: right;
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .review th[data-tip],
@@ -431,19 +484,19 @@ table {
   z-index: 50;
   max-width: 16rem;
   background: var(--text);
-  color: var(--bg);
-  font-size: 0.75rem;
+  color: var(--text-inverse);
+  font-size: var(--fs-2xs);
   line-height: 1.3;
-  padding: 0.4rem 0.6rem;
-  border-radius: 6px;
+  padding: var(--sp-6) var(--sp-10);
+  border-radius: var(--radius-sm);
   box-shadow: var(--shadow);
   pointer-events: none;
 }
 .section-row td {
   color: var(--muted);
   font-weight: 600;
-  font-size: 0.8rem;
-  padding-top: 0.7rem;
+  font-size: var(--fs-xs);
+  padding-top: var(--sp-12);
 }
 .subtotal-row td {
   font-weight: 600;
@@ -463,8 +516,8 @@ table {
 /* --- Consumption bar --- */
 .bar {
   position: relative;
-  background: var(--bg);
-  border-radius: 6px;
+  background: var(--surface-alt);
+  border-radius: var(--radius-sm);
   height: 1.1rem;
   min-width: 90px;
   overflow: hidden;
@@ -482,22 +535,23 @@ table {
 }
 .bar-pct {
   position: relative;
-  font-size: 0.75rem;
-  padding-left: 0.4rem;
+  font-size: var(--fs-2xs);
+  padding-left: var(--sp-6);
 }
 
 /* --- Filters --- */
 .filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.8rem;
+  gap: var(--sp-8);
+  margin-bottom: var(--sp-12);
 }
 .filters input,
 .filters select {
-  padding: 0.4rem 0.5rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-6) var(--sp-8);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--text);
 }
@@ -509,17 +563,17 @@ table {
 .date-field {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--sp-4);
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .date-field input {
   color: var(--text);
 }
 .ledger-count {
   color: var(--muted);
-  font-size: 0.85rem;
-  margin: 0 0 0.5rem;
+  font-size: var(--fs-sm);
+  margin: 0 0 var(--sp-8);
 }
 .load-more-cell {
   text-align: center;
@@ -528,12 +582,12 @@ table {
   display: inline-block;
   vertical-align: middle;
   max-width: 14rem;
-  font-size: 0.7rem;
+  font-size: var(--fs-2xs);
   color: var(--accent);
   border: 1px solid var(--accent);
-  border-radius: 4px;
-  padding: 0.15rem 0.4rem;
-  margin-left: 0.5rem;
+  border-radius: var(--radius-xs);
+  padding: var(--sp-2) var(--sp-6);
+  margin-left: var(--sp-8);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -547,13 +601,13 @@ a.link-tag {
 a.link-tag:hover,
 a.link-tag:focus-visible {
   background: var(--accent);
-  color: var(--bg);
+  color: var(--text-inverse);
   text-decoration: underline;
 }
 a.link-tag:focus-visible,
 a.overdue-edit:focus-visible,
 .link-action:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -561,16 +615,15 @@ a.overdue-edit:focus-visible,
 .chart {
   position: relative;
   height: 300px;
-  padding-left: 4.5rem;
+  padding-left: var(--axis-gutter);
 }
 .x-axis {
   display: flex;
   justify-content: space-between;
-  padding-left: 4.5rem;
-  margin-top: 0.3rem;
+  padding-left: var(--axis-gutter);
+  margin-top: var(--sp-4);
   color: var(--muted);
-  font-size: 0.7rem;
-  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-2xs);
 }
 .sparkline {
   width: 100%;
@@ -597,15 +650,14 @@ a.overdue-edit:focus-visible,
   left: 0;
   top: 0;
   bottom: 0;
-  width: 4.5rem;
+  width: var(--axis-gutter);
 }
 .y-label {
   position: absolute;
   right: 0.4rem;
   transform: translateY(-50%);
-  font-size: 0.7rem;
+  font-size: var(--fs-2xs);
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .y-label.zero {
@@ -618,11 +670,11 @@ a.overdue-edit:focus-visible,
   position: absolute;
   right: 0.3rem;
   transform: translateY(-50%);
-  font-size: 0.65rem;
+  font-size: var(--fs-2xs);
   color: var(--bad);
   background: var(--surface);
-  padding: 0 0.25rem;
-  border-radius: 4px;
+  padding: 0 var(--sp-4);
+  border-radius: var(--radius-xs);
   pointer-events: none;
 }
 .chart-cursor {
@@ -648,15 +700,15 @@ a.overdue-edit:focus-visible,
   top: -0.4rem;
   transform: translate(-50%, -100%);
   background: var(--text);
-  color: var(--bg);
-  font-size: 0.75rem;
+  color: var(--text-inverse);
+  font-size: var(--fs-2xs);
   white-space: nowrap;
-  padding: 0.2rem 0.45rem;
-  border-radius: 6px;
+  padding: var(--sp-4) var(--sp-8);
+  border-radius: var(--radius-sm);
   pointer-events: none;
 }
 .period-switch a {
-  padding: 0 0.4rem;
+  padding: 0 var(--sp-6);
   color: var(--muted);
 }
 .period-switch a.active {
@@ -670,9 +722,9 @@ a.overdue-edit:focus-visible,
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.75rem;
-  font-size: 0.8rem;
+  gap: var(--sp-6);
+  margin-top: var(--sp-12);
+  font-size: var(--fs-xs);
   color: var(--muted);
 }
 .threshold-control input[type='range'] {
@@ -681,7 +733,6 @@ a.overdue-edit:focus-visible,
   accent-color: var(--accent);
 }
 .threshold-control .threshold-value {
-  font-variant-numeric: tabular-nums;
   color: var(--text);
   font-weight: 600;
 }
@@ -692,7 +743,7 @@ a.overdue-edit:focus-visible,
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .donut {
   width: 260px;
@@ -701,6 +752,7 @@ a.overdue-edit:focus-visible,
 }
 .donut-total {
   fill: var(--text);
+  /* User units in a 200-unit viewBox rendered at 260px, not a font size. */
   font-size: 16px;
   font-weight: 700;
 }
@@ -718,27 +770,27 @@ a.overdue-edit:focus-visible,
   position: absolute;
   transform: translate(-50%, -110%);
   background: var(--text);
-  color: var(--bg);
-  padding: 0.4rem 0.6rem;
-  border-radius: 8px;
-  font-size: 0.8rem;
+  color: var(--text-inverse);
+  padding: var(--sp-6) var(--sp-10);
+  border-radius: var(--radius-md);
+  font-size: var(--fs-xs);
   white-space: nowrap;
   text-align: center;
   pointer-events: none;
 }
 .donut-tooltip .tt-muted {
   opacity: 0.75;
-  font-size: 0.75rem;
+  font-size: var(--fs-2xs);
 }
 .chart-hint {
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
   font-style: italic;
   margin: 0;
 }
 .donut-legend {
   list-style: none;
-  margin: 0.5rem 0 0;
+  margin: var(--sp-8) 0 0;
   padding: 0;
   width: 100%;
   max-width: 320px;
@@ -746,15 +798,15 @@ a.overdue-edit:focus-visible,
 .donut-legend li {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0;
+  gap: var(--sp-8);
+  padding: var(--sp-4) 0;
   border-bottom: 1px solid var(--border);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .donut-legend .swatch {
   width: 0.8rem;
   height: 0.8rem;
-  border-radius: 2px;
+  border-radius: var(--radius-2xs);
   flex: 0 0 auto;
 }
 .donut-legend .legend-label {
@@ -763,7 +815,6 @@ a.overdue-edit:focus-visible,
 }
 .donut-legend .legend-value {
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 /* Folded categories, listed under the grey "Other" legend row. */
@@ -775,12 +826,13 @@ a.overdue-edit:focus-visible,
 .donut-legend .legend-members ul {
   list-style: none;
   margin: 0;
-  padding: 0.15rem 0 0.3rem 1.3rem;
+  /* Indent aligns the sub-list under the label: swatch width + gap. */
+  padding: var(--sp-2) 0 var(--sp-4) calc(0.8rem + var(--sp-8));
 }
 .donut-legend .legend-members li {
   border-bottom: none;
-  padding: 0.1rem 0;
-  font-size: 0.8rem;
+  padding: var(--sp-2) 0;
+  font-size: var(--fs-xs);
   color: var(--muted);
 }
 
@@ -788,22 +840,22 @@ a.overdue-edit:focus-visible,
 .kv {
   display: flex;
   justify-content: space-between;
-  padding: 0.3rem 0;
+  padding: var(--sp-4) 0;
 }
 .kv code {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .hint {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
   font-style: italic;
 }
 .status-valid {
   color: var(--good);
 }
 .status-expiring {
-  color: #b8860b;
+  color: var(--warn);
 }
 .status-expired {
   color: var(--bad);
@@ -817,18 +869,18 @@ a.overdue-edit:focus-visible,
 .sync-runs {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .sync-runs th {
   color: var(--muted);
-  font-weight: 500;
-  font-size: 0.8rem;
+  font-weight: 600;
+  font-size: var(--fs-xs);
   text-align: left;
-  padding: 0.3rem 0.5rem;
+  padding: var(--sp-4) var(--sp-8);
   border-bottom: 1px solid var(--border);
 }
 .sync-runs td {
-  padding: 0.35rem 0.5rem;
+  padding: var(--sp-6) var(--sp-8);
   border-bottom: 1px solid var(--border);
 }
 .sync-runs th.num,
@@ -843,12 +895,12 @@ a.overdue-edit:focus-visible,
 }
 .tag {
   display: inline-block;
-  margin-left: 0.4rem;
-  padding: 0 0.35rem;
-  border-radius: 6px;
+  margin-left: var(--sp-6);
+  padding: 0 var(--sp-6);
+  border-radius: var(--radius-sm);
   background: var(--border);
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: var(--fs-2xs);
   font-weight: 500;
 }
 
@@ -858,39 +910,41 @@ a.overdue-edit:focus-visible,
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  padding: 1rem;
+  padding: var(--sp-16);
 }
 .login-card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  padding: var(--sp-24);
   width: 100%;
   max-width: 320px;
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: var(--sp-10);
 }
 .login-card input {
-  padding: 0.6rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-10);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg);
+  border-radius: var(--radius-md);
+  background: var(--surface);
   color: var(--text);
 }
 .login-card button {
-  padding: 0.6rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-10);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   font-weight: 600;
   cursor: pointer;
 }
 .login-error {
   color: var(--bad);
-  font-size: 0.9rem;
+  font-size: var(--fs-sm);
   margin: 0;
 }
 
@@ -906,17 +960,17 @@ a.overdue-edit:focus-visible,
     top: 0;
     left: 0;
     bottom: 0;
-    width: 200px;
-    padding: 1rem;
+    width: var(--sidebar-w);
+    padding: var(--sp-16);
     background: var(--surface);
     border-right: 1px solid var(--border);
   }
   .sidebar .nav-item {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    padding: 0.6rem 0.5rem;
-    border-radius: 8px;
+    gap: var(--sp-10);
+    padding: var(--sp-10) var(--sp-8);
+    border-radius: var(--radius-md);
     color: var(--muted);
   }
   .sidebar .nav-item.active {
@@ -928,16 +982,16 @@ a.overdue-edit:focus-visible,
     margin-top: auto;
   }
   .content {
-    margin-left: 200px;
+    margin-left: var(--sidebar-w);
     margin-right: 0;
-    max-width: 1500px;
-    padding: 1.5rem 2rem;
+    max-width: var(--content-max-wide);
+    padding: var(--sp-24) var(--sp-32);
   }
   /* Tile the two lower home cards side by side on wide screens. */
   .home-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1rem;
+    gap: var(--sp-16);
     align-items: start;
   }
 }
@@ -946,7 +1000,7 @@ a.overdue-edit:focus-visible,
 @media (max-width: 1023px) {
   .review,
   .ledger {
-    font-size: 0.8rem;
+    font-size: var(--fs-xs);
   }
   /* Month review: a card per category with every figure labelled, so nothing
      is lost to a hidden column or off-screen scroll. */
@@ -961,8 +1015,8 @@ a.overdue-edit:focus-visible,
   .review tr.expense {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0.15rem 0.8rem;
-    padding: 0.55rem 0;
+    gap: var(--sp-2) var(--sp-12);
+    padding: var(--sp-8) 0;
     border-bottom: 1px solid var(--border);
   }
   .review tr.income td,
@@ -978,7 +1032,7 @@ a.overdue-edit:focus-visible,
   .review td[data-label]::before {
     content: attr(data-label) ' : ';
     color: var(--muted);
-    font-size: 0.72rem;
+    font-size: var(--fs-2xs);
   }
   .review .bar-cell {
     grid-column: 1 / -1;
@@ -992,7 +1046,7 @@ a.overdue-edit:focus-visible,
   .review .subtotal-row,
   .review .total-row {
     display: block;
-    padding-top: 0.5rem;
+    padding-top: var(--sp-8);
   }
   .review .subtotal-row td,
   .review .total-row td {
@@ -1013,7 +1067,7 @@ a.overdue-edit:focus-visible,
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
-    padding: 0.5rem 0;
+    padding: var(--sp-8) 0;
     border-bottom: 1px solid var(--border);
   }
   .ledger td {
@@ -1028,7 +1082,7 @@ a.overdue-edit:focus-visible,
   }
   .ledger .desc {
     flex-basis: 100%;
-    margin-top: 0.15rem;
+    margin-top: var(--sp-2);
   }
   .ledger .cat {
     display: none;
@@ -1050,8 +1104,8 @@ a.overdue-edit:focus-visible,
   .sync-runs tr {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0.15rem 0.8rem;
-    padding: 0.55rem 0;
+    gap: var(--sp-2) var(--sp-12);
+    padding: var(--sp-8) 0;
     border-bottom: 1px solid var(--border);
   }
   .sync-runs td {
@@ -1065,7 +1119,7 @@ a.overdue-edit:focus-visible,
   .sync-runs td[data-label]::before {
     content: attr(data-label) ' : ';
     color: var(--muted);
-    font-size: 0.72rem;
+    font-size: var(--fs-2xs);
   }
   .sync-runs td:first-child,
   .sync-runs td:last-child {
@@ -1103,21 +1157,25 @@ a.overdue-edit:focus-visible,
 
 /* --- Buttons --- */
 .btn {
-  display: inline-block;
-  padding: 0.45rem 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--control-min-h);
+  padding: var(--sp-8) var(--sp-12);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--accent);
   font: inherit;
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: var(--fs-sm);
   text-align: center;
   cursor: pointer;
 }
 .btn.primary {
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--accent);
 }
 .btn.danger {
@@ -1125,8 +1183,8 @@ a.overdue-edit:focus-visible,
   border-color: var(--bad);
 }
 .btn.small {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.8rem;
+  padding: var(--sp-4) var(--sp-8);
+  font-size: var(--fs-xs);
 }
 /* An author display rule beats the UA [hidden] rule, so say it explicitly. */
 .btn[hidden] {
@@ -1141,9 +1199,9 @@ a.overdue-edit:focus-visible,
 }
 .bookmarklet {
   display: inline-block;
-  padding: 0.45rem 0.9rem;
+  padding: var(--sp-8) var(--sp-14);
   border: 1px dashed var(--accent);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--accent);
   font-weight: 600;
@@ -1154,16 +1212,19 @@ a.overdue-edit:focus-visible,
 /* --- "N to categorize" badge --- */
 .badge {
   display: inline-block;
+  /* A nav row is flex: without this the count is what gets squeezed, and a
+     two-digit badge loses its second digit. */
+  flex-shrink: 0;
   min-width: 1.1rem;
-  margin-left: 0.35rem;
-  padding: 0 0.35rem;
-  font-size: 0.7rem;
+  margin-left: var(--sp-6);
+  padding: var(--sp-4) var(--sp-6);
+  font-size: var(--fs-2xs);
   font-weight: 700;
-  line-height: 1.15rem;
+  line-height: 1;
   text-align: center;
-  color: #fff;
+  color: var(--on-accent);
   background: var(--accent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 .badge[hidden] {
   display: none;
@@ -1176,6 +1237,7 @@ a.overdue-edit:focus-visible,
   padding: 0;
   color: var(--accent);
   font: inherit;
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
   cursor: pointer;
   text-align: left;
@@ -1196,32 +1258,32 @@ a.overdue-edit:focus-visible,
   display: none;
 }
 .cat-detail {
-  background: var(--bg);
+  background: var(--surface-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.7rem 0.9rem;
-  margin: 0.2rem 0 0.6rem;
+  border-radius: var(--radius-md);
+  padding: var(--sp-12) var(--sp-14);
+  margin: var(--sp-4) 0 var(--sp-10);
 }
 .detail-slot:focus {
   outline: none;
 }
 .cat-detail h3 {
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
   color: var(--muted);
-  margin: 0.6rem 0 0.3rem;
+  margin: var(--sp-10) 0 var(--sp-4);
 }
 .cat-detail-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .cat-detail-head h3 {
   margin: 0;
 }
 .add-menu {
   display: flex;
-  gap: 0.4rem;
+  gap: var(--sp-6);
 }
 .source-list,
 .attributed-list {
@@ -1233,8 +1295,8 @@ a.overdue-edit:focus-visible,
 .attributed-list li {
   display: flex;
   justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.4rem 0;
+  gap: var(--sp-8);
+  padding: var(--sp-6) 0;
   border-bottom: 1px solid var(--border);
   color: inherit;
 }
@@ -1244,12 +1306,11 @@ a.overdue-edit:focus-visible,
   cursor: pointer;
 }
 .attributed-row:hover {
-  background: var(--bg);
+  background: var(--surface-hover);
 }
 .src-meta,
 .op-amount {
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .attributed-list .op-date {
@@ -1266,7 +1327,7 @@ a.overdue-edit:focus-visible,
 }
 .annot {
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
 }
 
 /* --- Operations: selection + inline categorize --- */
@@ -1290,7 +1351,9 @@ a.overdue-edit:focus-visible,
     width: 7.5rem;
   }
   .ledger .cat {
-    width: 13rem;
+    /* Fits the category select plus the link icon beside it; at 13rem the icon
+       spilled out of the cell and the card clipped it. */
+    width: 15rem;
   }
   .ledger .desc {
     overflow-wrap: anywhere;
@@ -1299,16 +1362,16 @@ a.overdue-edit:focus-visible,
 .cat-actions {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--sp-6);
 }
 /* Secondary action: revealed on row hover/focus (desktop), hidden on mobile
    where tapping the operation opens its detail page with a link action. */
 .link-action {
-  font-size: 1rem;
+  font-size: var(--fs-base);
   line-height: 1;
   text-decoration: none;
   opacity: 0.7;
-  padding: 0.15rem;
+  padding: var(--sp-2);
 }
 .link-action:hover {
   opacity: 1;
@@ -1323,9 +1386,13 @@ a.overdue-edit:focus-visible,
   }
 }
 .row-category {
-  padding: 0.2rem 0.3rem;
+  /* Shrinks with the cell instead of pushing the link icon out of it. */
+  min-width: 0;
+  /* No --control-min-h here: 102 of these sit in the ledger, and their
+     height is the ledger's density, which is not this file's call. */
+  padding: var(--sp-4) var(--sp-4);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
   color: var(--text);
   max-width: 12rem;
@@ -1343,51 +1410,53 @@ a.overdue-edit:focus-visible,
   z-index: 9;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  padding-bottom: calc(0.6rem + env(safe-area-inset-bottom));
+  gap: var(--sp-8);
+  padding: var(--sp-10) var(--sp-16);
+  padding-bottom: calc(var(--sp-10) + env(safe-area-inset-bottom));
   background: var(--surface);
   border-top: 1px solid var(--border);
-  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-up);
 }
 .bulk-bar[hidden] {
   display: none;
 }
 .bulk-count {
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
   color: var(--muted);
 }
 .bulk-bar select {
   flex: 1;
   min-width: 0;
-  padding: 0.35rem 0.4rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-6) var(--sp-6);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
   color: var(--text);
 }
 
 /* --- Forms (target edit) --- */
 .form-page h1 {
-  font-size: 1.2rem;
-  margin: 0 0 1rem;
+  font-size: var(--fs-md);
+  margin: 0 0 var(--sp-16);
 }
 .field {
   display: block;
-  margin-bottom: 0.8rem;
+  margin-bottom: var(--sp-12);
 }
 .field > span {
   display: block;
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
   color: var(--muted);
-  margin-bottom: 0.2rem;
+  margin-bottom: var(--sp-4);
 }
 .field input,
 .field select {
   width: 100%;
-  padding: 0.5rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-8);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--text);
 }
@@ -1396,7 +1465,7 @@ a.overdue-edit:focus-visible,
 }
 .duration {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 /* width:auto lets flex size the pair; the generic .field width:100% would
    otherwise fight the flex layout. */
@@ -1409,51 +1478,51 @@ a.overdue-edit:focus-visible,
   width: auto;
 }
 .check-field {
-  margin-bottom: 0.8rem;
+  margin-bottom: var(--sp-12);
 }
 .check-field label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
   cursor: pointer;
 }
 .form-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 1.5rem;
+  gap: var(--sp-8);
+  margin-top: var(--sp-24);
 }
 .actions-spacer {
   flex: 1;
 }
 .form-error {
-  background: #fbe0e0;
-  color: #7a1616;
-  border-radius: 8px;
-  padding: 0.6rem 0.8rem;
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
+  background: var(--error-bg);
+  color: var(--error-text);
+  border-radius: var(--radius-md);
+  padding: var(--sp-10) var(--sp-12);
+  margin-bottom: var(--sp-16);
+  font-size: var(--fs-sm);
 }
 /* Says something useful about the form without taking it over. */
 .seed-notice {
   border-left: 3px solid var(--accent);
-  padding: 0.4rem 0.7rem;
-  margin: 0 0 1rem;
-  font-size: 0.9rem;
+  padding: var(--sp-6) var(--sp-12);
+  margin: 0 0 var(--sp-16);
+  font-size: var(--fs-sm);
   color: var(--muted);
 }
 .field > span.hint {
-  margin: 0.25rem 0 0;
+  margin: var(--sp-4) 0 0;
 }
 .import-form {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
   flex-wrap: wrap;
 }
 .import-result {
-  margin: 0.75rem 0 0;
-  font-size: 0.9rem;
+  margin: var(--sp-12) 0 0;
+  font-size: var(--fs-sm);
 }
 .import-result.ok {
   color: var(--good);
@@ -1463,19 +1532,19 @@ a.overdue-edit:focus-visible,
 }
 .advanced,
 .split {
-  margin: 0.5rem 0;
+  margin: var(--sp-8) 0;
 }
 .advanced summary {
   cursor: pointer;
   color: var(--accent);
   font-weight: 600;
-  font-size: 0.9rem;
-  padding: 0.3rem 0;
+  font-size: var(--fs-sm);
+  padding: var(--sp-4) 0;
 }
 /* The split disclosure opens with a plain button, not a triangle marker. */
 .split > summary {
   list-style: none;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--sp-8);
 }
 .split > summary::-webkit-details-marker {
   display: none;
@@ -1483,13 +1552,13 @@ a.overdue-edit:focus-visible,
 .delete-form {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
   margin: 0;
 }
 .confirm-cluster {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .confirm-cluster[hidden] {
   display: none;
@@ -1497,25 +1566,25 @@ a.overdue-edit:focus-visible,
 
 /* --- /targets management list --- */
 .targets-page > h1 {
-  font-size: 1.3rem;
-  margin: 0 0 1rem;
+  font-size: var(--fs-md);
+  margin: 0 0 var(--sp-16);
 }
 .seg {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--sp-4);
   width: fit-content;
-  margin-bottom: 1rem;
-  padding: 0.2rem;
-  background: var(--bg);
+  margin-bottom: var(--sp-16);
+  padding: var(--sp-4);
+  background: var(--surface-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 .seg a {
-  padding: 0.35rem 0.8rem;
-  border-radius: 6px;
+  padding: var(--sp-6) var(--sp-12);
+  border-radius: var(--radius-sm);
   color: var(--muted);
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: var(--fs-sm);
 }
 .seg a.active {
   background: var(--surface);
@@ -1526,17 +1595,17 @@ a.overdue-edit:focus-visible,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--sp-8);
 }
 .list-head h2 {
-  font-size: 1rem;
+  font-size: var(--fs-base);
   margin: 0;
 }
 .target-row {
   cursor: pointer;
 }
 .target-row:hover {
-  background: var(--bg);
+  background: var(--surface-hover);
 }
 .target-row.inactive {
   opacity: 0.55;
@@ -1545,50 +1614,52 @@ a.overdue-edit:focus-visible,
 /* --- Link flow --- */
 .link-page h1,
 .op-detail h1 {
-  font-size: 1.2rem;
-  margin: 0.3rem 0 1rem;
+  font-size: var(--fs-md);
+  margin: var(--sp-4) 0 var(--sp-16);
 }
 .op-detail .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .back {
-  margin: 0 0 0.5rem;
-  font-size: 0.9rem;
+  margin: 0 0 var(--sp-8);
+  font-size: var(--fs-sm);
 }
 .op-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--sp-8);
   align-items: baseline;
-  padding: 0.6rem;
-  background: var(--bg);
-  border-radius: 8px;
-  margin-bottom: 1rem;
+  padding: var(--sp-10);
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--sp-16);
 }
 .op-summary .op-desc {
   flex: 1;
   font-weight: 600;
 }
 .current-link {
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
+  margin-bottom: var(--sp-16);
+  font-size: var(--fs-sm);
 }
 .type-toggle {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: var(--sp-8);
+  margin-bottom: var(--sp-16);
 }
 .candidate-search {
   width: 100%;
-  padding: 0.5rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-8);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--text);
   font: inherit;
-  margin-bottom: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: var(--sp-12);
 }
 .candidate-list {
   list-style: none;
@@ -1597,16 +1668,18 @@ a.overdue-edit:focus-visible,
 }
 .candidate {
   display: flex;
+  min-height: var(--control-min-h);
   align-items: baseline;
-  gap: 0.6rem;
+  gap: var(--sp-10);
   width: 100%;
-  padding: 0.5rem;
+  padding: var(--sp-8);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  margin-bottom: 0.4rem;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--sp-6);
   background: var(--surface);
   color: inherit;
   font: inherit;
+  font-variant-numeric: tabular-nums;
   cursor: pointer;
   text-align: left;
 }
@@ -1625,40 +1698,39 @@ a.overdue-edit:focus-visible,
   flex: 1;
 }
 .cand-amount {
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .cand-reason {
-  font-size: 0.7rem;
+  font-size: var(--fs-2xs);
   color: var(--accent);
   border: 1px solid var(--accent);
-  border-radius: 4px;
-  padding: 0 0.3rem;
+  border-radius: var(--radius-xs);
+  padding: 0 var(--sp-4);
 }
 
 /* --- picking the operation that paid an overdue iteration --- */
 .settle-summary {
-  padding: 0.6rem;
-  background: var(--bg);
-  border-radius: 8px;
-  margin-bottom: 1rem;
+  padding: var(--sp-10);
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--sp-16);
 }
 .candidate-item {
-  margin-bottom: 0.4rem;
+  margin-bottom: var(--sp-6);
 }
 /* Stacked: the description leads, and a bank label needs the width. */
 .candidate-stacked {
   flex-direction: column;
   align-items: stretch;
-  gap: 0.15rem;
-  min-height: 44px;
+  gap: var(--sp-2);
+  min-height: var(--control-min-h);
   margin-bottom: 0;
 }
 .cand-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.6rem;
+  gap: var(--sp-10);
 }
 .cand-head .cand-desc {
   min-width: 0;
@@ -1666,7 +1738,7 @@ a.overdue-edit:focus-visible,
 }
 .cand-meta,
 .cand-badge {
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
   color: var(--muted);
 }
 .cand-badge {
@@ -1680,11 +1752,11 @@ a.overdue-edit:focus-visible,
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: var(--sp-8);
+  padding: var(--sp-8);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg);
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
 }
 .candidate-item .confirm-cluster[hidden] {
   display: none;
@@ -1693,8 +1765,8 @@ a.overdue-edit:focus-visible,
   flex-basis: 100%;
 }
 .settle-rest {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
+  margin-top: var(--sp-24);
+  padding-top: var(--sp-16);
   border-top: 1px solid var(--border);
 }
 .postpone-details summary {
@@ -1706,7 +1778,7 @@ a.overdue-edit:focus-visible,
   display: none;
 }
 .iter-slot {
-  margin-top: 1rem;
+  margin-top: var(--sp-16);
 }
 .iter-slot:focus {
   outline: none;
@@ -1714,37 +1786,36 @@ a.overdue-edit:focus-visible,
 .iter-nav {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .iter-window {
   font-weight: 600;
 }
 .iter-list {
   list-style: none;
-  margin: 0.5rem 0;
+  margin: var(--sp-8) 0;
   padding: 0;
 }
 .iter-list label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0;
+  gap: var(--sp-8);
+  padding: var(--sp-6) 0;
   border-bottom: 1px solid var(--border);
 }
 .iter-score {
   margin-left: auto;
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
 }
 .detail-grid {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.4rem 1rem;
+  gap: var(--sp-6) var(--sp-16);
   margin: 0;
 }
 .detail-grid dt {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .detail-grid dd {
   margin: 0;
@@ -1754,12 +1825,12 @@ a.overdue-edit:focus-visible,
 @media (min-width: 1024px) {
   .bulk-bar {
     bottom: 0;
-    left: 200px;
+    left: var(--sidebar-w);
   }
   .link-cols {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
+    gap: var(--sp-24);
     align-items: start;
   }
   .iter-slot {
@@ -1775,7 +1846,7 @@ a.overdue-edit:focus-visible,
   }
   .ledger .cat {
     flex-basis: 100%;
-    margin-top: 0.35rem;
+    margin-top: var(--sp-6);
   }
   .ledger .cat::before {
     content: none;
@@ -1790,14 +1861,14 @@ a.overdue-edit:focus-visible,
   }
   .ledger .select-cell {
     flex: 0 0 auto;
-    margin-right: 0.5rem;
+    margin-right: var(--sp-8);
   }
 
   .review tr.target-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0.15rem 0.8rem;
-    padding: 0.55rem 0;
+    gap: var(--sp-2) var(--sp-12);
+    padding: var(--sp-8) 0;
     border-bottom: 1px solid var(--border);
   }
   .review tr.target-row td {
@@ -1815,26 +1886,26 @@ a.overdue-edit:focus-visible,
 .status-with-action {
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: var(--sp-10);
 }
 .back-link {
-  font-size: 0.9rem;
-  margin-bottom: 0.3rem;
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-4);
 }
 .bank-list {
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.3rem;
-  margin: 0.8rem 0;
+  border-radius: var(--radius-md);
+  padding: var(--sp-4);
+  margin: var(--sp-12) 0;
   max-height: 22rem;
   overflow-y: auto;
 }
 .bank-option {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.55rem 0.6rem;
-  border-radius: 6px;
+  gap: var(--sp-10);
+  padding: var(--sp-8) var(--sp-10);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 .bank-option:hover {
@@ -1845,13 +1916,14 @@ a.overdue-edit:focus-visible,
 }
 .inline-cta {
   display: inline;
-  margin-left: 0.5rem;
+  margin-left: var(--sp-8);
 }
 .link-button {
   background: none;
   border: none;
   padding: 0;
   font: inherit;
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
   color: inherit;
   text-decoration: underline;
@@ -1864,7 +1936,7 @@ a.overdue-edit:focus-visible,
   border-collapse: collapse;
 }
 .backups td {
-  padding: 0.45rem 0.5rem;
+  padding: var(--sp-8) var(--sp-8);
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
 }
@@ -1874,7 +1946,7 @@ a.overdue-edit:focus-visible,
 }
 .backup-actions {
   display: flex;
-  gap: 0.4rem;
+  gap: var(--sp-6);
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
@@ -1883,16 +1955,16 @@ a.overdue-edit:focus-visible,
   line-height: 1;
 }
 .backup-preview {
-  margin-top: 1rem;
+  margin-top: var(--sp-16);
 }
 .backup-preview-table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--sp-12);
 }
 .backup-preview-table th,
 .backup-preview-table td {
-  padding: 0.35rem 0.5rem;
+  padding: var(--sp-6) var(--sp-8);
   text-align: left;
   border-bottom: 1px solid var(--border);
 }
@@ -1908,7 +1980,7 @@ a.overdue-edit:focus-visible,
   .backups td {
     display: block;
     border: none;
-    padding: 0.1rem 0;
+    padding: var(--sp-2) 0;
     text-align: left;
   }
   .backups td.num {
@@ -1916,28 +1988,28 @@ a.overdue-edit:focus-visible,
   }
   .backups tr {
     display: block;
-    padding: 0.55rem 0;
+    padding: var(--sp-8) 0;
     border-bottom: 1px solid var(--border);
   }
   .backups td[data-label]::before {
     content: attr(data-label) ' : ';
     color: var(--muted);
-    font-size: 0.72rem;
+    font-size: var(--fs-2xs);
   }
   .backup-actions {
     justify-content: flex-start;
-    margin-top: 0.35rem;
+    margin-top: var(--sp-6);
   }
 }
 
 /* --- Accueil overdue card --- */
 .overdue-card .card-head {
   align-items: baseline;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .card-note {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .overdue-list {
   list-style: none;
@@ -1945,7 +2017,7 @@ a.overdue-edit:focus-visible,
   padding: 0;
 }
 .overdue-item {
-  padding: 0.6rem 0;
+  padding: var(--sp-10) 0;
   border-bottom: 1px solid var(--border);
 }
 .overdue-item:last-child {
@@ -1954,7 +2026,7 @@ a.overdue-edit:focus-visible,
 .overdue-head {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: var(--sp-8);
 }
 .overdue-desc {
   flex: 1;
@@ -1974,9 +2046,9 @@ a.overdue-edit {
   align-items: center;
   justify-content: center;
   align-self: center;
-  min-width: 44px;
-  min-height: 44px;
-  font-size: 0.9rem;
+  min-width: var(--control-min-h);
+  min-height: var(--control-min-h);
+  font-size: var(--fs-sm);
   text-decoration: none;
   opacity: 0.7;
 }
@@ -1984,13 +2056,12 @@ a.overdue-edit:hover {
   opacity: 1;
 }
 .overdue-amount {
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .overdue-meta {
   color: var(--muted);
-  font-size: 0.85rem;
-  margin-top: 0.15rem;
+  font-size: var(--fs-sm);
+  margin-top: var(--sp-2);
 }
 .not-counted {
   color: var(--warn);
@@ -2001,9 +2072,9 @@ a.overdue-edit:hover {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  min-height: 44px;
-  margin-top: 0.25rem;
+  gap: var(--sp-8);
+  min-height: var(--control-min-h);
+  margin-top: var(--sp-4);
 }
 .overdue-actions form.inline {
   margin-left: auto;
@@ -2011,50 +2082,49 @@ a.overdue-edit:hover {
 .overdue-actions .btn.small,
 .decided-head .btn.small,
 .postpone-form .btn.small {
-  min-height: 44px;
-  padding: 0.6rem 0.9rem;
-  font-size: 0.85rem;
+  padding: var(--sp-10) var(--sp-14);
+  font-size: var(--fs-sm);
 }
 .confirm-question {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .overdue-item.settled .overdue-desc {
   font-weight: 400;
   color: var(--muted);
 }
 .overdue-degraded {
-  margin: 0.5rem 0;
+  margin: var(--sp-8) 0;
 }
 .muted-note {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: var(--fs-sm);
 }
 .card-foot {
   color: var(--muted);
-  font-size: 0.8rem;
-  margin: 0.5rem 0 0;
+  font-size: var(--fs-xs);
+  margin: var(--sp-8) 0 0;
 }
 .postpone-label {
   color: var(--muted);
-  font-size: 0.85rem;
-  margin-top: 0.35rem;
+  font-size: var(--fs-sm);
+  margin-top: var(--sp-6);
 }
 .chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin: 0.35rem 0;
+  gap: var(--sp-6);
+  margin: var(--sp-6) 0;
 }
 .postpone-other {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  gap: var(--sp-8);
+  font-size: var(--fs-sm);
   color: var(--muted);
 }
 .postpone-other input[type='date'] {
-  padding: 0.35rem;
+  padding: var(--sp-6);
 }
 
 /* --- decided occurrences on a planned operation --- */
@@ -2064,7 +2134,7 @@ a.overdue-edit:hover {
   padding: 0;
 }
 .decided-list li {
-  padding: 0.5rem 0;
+  padding: var(--sp-8) 0;
   border-bottom: 1px solid var(--border);
 }
 .decided-list li:last-child {
@@ -2073,13 +2143,13 @@ a.overdue-edit:hover {
 .decided-head {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  min-height: 44px;
+  gap: var(--sp-8);
+  min-height: var(--control-min-h);
 }
 .decided-what {
   flex: 1;
 }
 .decided-when {
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--fs-xs);
 }

--- a/tests/web/.custom.dic
+++ b/tests/web/.custom.dic
@@ -3,6 +3,7 @@ affordance
 basename
 bnp
 bookmarklet
+colours
 config
 dir
 donut
@@ -15,10 +16,13 @@ hx
 mis
 oob
 orchestrator
+paddings
 passthrough
 postponable
 réglages
 sparkline
+stylesheet
+stylesheet's
 summarised
 supersession
 supersession

--- a/tests/web/test_stylesheet_tokens.py
+++ b/tests/web/test_stylesheet_tokens.py
@@ -2,6 +2,9 @@
 
 Without this, each use site writes its own literal: that is how the file reached
 eighteen font sizes and five near-identical paddings.
+
+Not guarded yet, because each needs its own token first: `border` (a hairline
+width), `width` / `height`, and `font-weight`.
 """
 
 from __future__ import annotations
@@ -13,10 +16,12 @@ STYLESHEET = (
     Path(__file__).parents[2] / "budget_forecaster" / "web" / "static" / "app.css"
 )
 
-# Properties whose value must resolve to a token.
 GUARDED = re.compile(
-    r"^(font-size|border-radius|box-shadow|min-height|color|background-color|outline"
-    r"|padding(-top|-right|-bottom|-left)?|margin(-top|-right|-bottom|-left)?|gap)$"
+    r"^(font-size|line-height|border-radius|box-shadow|min-height|color"
+    r"|background|background-color|outline|outline-offset"
+    r"|padding(-top|-right|-bottom|-left|-inline|-block)?"
+    r"|margin(-top|-right|-bottom|-left|-inline|-block)?"
+    r"|(row-|column-)?gap)$"
 )
 
 KEYWORDS = {
@@ -29,55 +34,81 @@ KEYWORDS = {
     "currentColor",
 }
 
-# Values that carry no design decision, whatever the property.
-FREE_VALUES = {"0", "50%", "100vh", "100%"}
+# Unitless line heights and zero carry no design decision.
+FREE = re.compile(r"^(0|1|[0-9]*\.[0-9]+)$")
 
-# (selector, property) -> why this one stays literal. Anything not listed must
-# use a token, so adding an entry here is a deliberate, reviewed exception.
-EXEMPT: dict[tuple[str, str], str] = {
-    (".bottombar .badge", "margin-left"): "nudge off the centre line, not spacing",
-    (".chart-dot", "margin"): "negative half of its own width",
-    (".sr-only", "margin"): "the visually-hidden clip trick",
-    (".donut-total", "font-size"): "SVG user units in a viewBox, not a font size",
-    (".donut-legend .legend-members ul", "padding"): "indent derived from swatch + gap",
+# selector -> why this one stays literal. Keys are the selector as written, with
+# whitespace collapsed. Anything absent must use a token, so an entry here is a
+# deliberate exception — and `test_exemptions_are_needed` fails once it is not.
+EXEMPT: dict[str, str] = {
+    ".bottombar .badge": "nudge off the centre line, not spacing",
+    ".chart-dot": "negative half of its own width",
+    ".sr-only": "the visually-hidden clip trick",
+    ".donut-total": "SVG user units in a viewBox, not a font size",
+    ".login-body": "a full-viewport login screen",
 }
+
+_VAR = re.compile(r"var\(\s*(--[\w-]+)\s*\)")
+_ENV = re.compile(r"env\([^()]*\)")
+_CALL = re.compile(r"[\w-]*\(")
+
+
+def _rules() -> list[tuple[str, str]]:
+    """Every (selector, declaration block) pair, comments stripped."""
+    css = re.sub(r"/\*.*?\*/", "", STYLESHEET.read_text(), flags=re.S)
+    rules: list[tuple[str, str]] = []
+    pending: list[str] = []
+    buffer = ""
+    for char in css:
+        if char == "{":
+            pending.append(" ".join(buffer.split()))
+            buffer = ""
+        elif char == "}":
+            rules.append((pending.pop() if pending else "", buffer))
+            buffer = ""
+        else:
+            buffer += char
+    return rules
 
 
 def _declarations() -> list[tuple[str, str, str]]:
-    """Every (selector, property, value) in the stylesheet, tokens themselves aside."""
-    css = re.sub(r"/\*.*?\*/", "", STYLESHEET.read_text(), flags=re.S)
-    found: list[tuple[str, str, str]] = []
-    stack: list[str] = []
-    for chunk in re.split(r"([{}])", css):
-        if chunk == "{":
-            continue
-        if chunk == "}":
-            if stack:
-                stack.pop()
-            continue
-        head, _, decls = chunk.rpartition(";")
-        body = f"{head};{decls}" if head else decls
-        for decl in body.split(";"):
+    """Every (selector, property, value), token definitions aside."""
+    found = []
+    for selector, block in _rules():
+        for decl in block.split(";"):
             prop, sep, value = decl.partition(":")
-            if not sep:
-                continue
-            prop, value = prop.strip(), value.strip()
-            if prop and value and not prop.startswith("--"):
-                found.append((stack[-1] if stack else "", prop, value))
-        selector = decls.strip().splitlines()[-1].strip() if decls.strip() else ""
-        stack.append(selector)
+            prop, value = prop.strip().lower(), value.strip()
+            if sep and prop and value and not prop.startswith("--"):
+                found.append((selector, prop, value))
     return found
 
 
-_FUNCTION = re.compile(r"[a-z-]*\((?:[^()]|\([^()]*\))*\)")
+def _strip_calls(value: str) -> str:
+    """Bare the arguments so a literal cannot hide inside a function.
+
+    `var(--x, 7px)` keeps its fallback: that is a literal wearing a token's
+    clothes. `env()` names a platform inset, so it goes whole.
+    """
+    value = _ENV.sub(" ", _VAR.sub(" ", value))
+    return _CALL.sub(" ", value).replace(")", " ").replace(",", " ")
 
 
 def _is_tokenised(value: str) -> bool:
-    """True when nothing outside a function call is a bare literal."""
+    """True when nothing left after resolving tokens is a bare literal."""
+    # A percentage is a mix ratio inside color-mix(), a length anywhere else.
+    ratio = "color-mix(" in value
+    parts = _strip_calls(value).split()
     return all(
-        part in KEYWORDS or part in FREE_VALUES
-        for part in _FUNCTION.sub(" ", value).split()
+        part in KEYWORDS
+        or FREE.match(part)
+        or _is_operator(part)
+        or (ratio and part.endswith("%"))
+        for part in parts
     )
+
+
+def _is_operator(part: str) -> bool:
+    return part in {"+", "-", "*", "/", "solid", "dashed", "in", "srgb"}
 
 
 def test_guarded_properties_use_tokens() -> None:
@@ -85,14 +116,18 @@ def test_guarded_properties_use_tokens() -> None:
     offenders = [
         f"{selector} {{ {prop}: {value} }}"
         for selector, prop, value in _declarations()
-        if GUARDED.match(prop)
-        and not _is_tokenised(value)
-        and (selector, prop) not in EXEMPT
+        if GUARDED.match(prop) and not _is_tokenised(value) and selector not in EXEMPT
     ]
     assert not offenders, "literal values outside :root:\n" + "\n".join(offenders)
 
 
-def test_exemptions_still_apply() -> None:
-    """An exemption matching nothing is stale."""
-    live = {(selector, prop) for selector, prop, _ in _declarations()}
-    assert not [key for key in EXEMPT if key not in live]
+def test_exemptions_are_needed() -> None:
+    """An exemption whose value would now pass on its own is stale."""
+    stale = [
+        selector
+        for selector, prop, value in _declarations()
+        if selector in EXEMPT and GUARDED.match(prop) and not _is_tokenised(value)
+    ]
+    assert set(EXEMPT) == set(
+        stale
+    ), f"stale exemptions: {sorted(set(EXEMPT) - set(stale))}"

--- a/tests/web/test_stylesheet_tokens.py
+++ b/tests/web/test_stylesheet_tokens.py
@@ -1,0 +1,98 @@
+"""Sizes, colours and shadows in the stylesheet must come from :root tokens.
+
+Without this, each use site writes its own literal: that is how the file reached
+eighteen font sizes and five near-identical paddings.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+STYLESHEET = (
+    Path(__file__).parents[2] / "budget_forecaster" / "web" / "static" / "app.css"
+)
+
+# Properties whose value must resolve to a token.
+GUARDED = re.compile(
+    r"^(font-size|border-radius|box-shadow|min-height|color|background-color|outline"
+    r"|padding(-top|-right|-bottom|-left)?|margin(-top|-right|-bottom|-left)?|gap)$"
+)
+
+KEYWORDS = {
+    "auto",
+    "inherit",
+    "initial",
+    "unset",
+    "none",
+    "transparent",
+    "currentColor",
+}
+
+# Values that carry no design decision, whatever the property.
+FREE_VALUES = {"0", "50%", "100vh", "100%"}
+
+# (selector, property) -> why this one stays literal. Anything not listed must
+# use a token, so adding an entry here is a deliberate, reviewed exception.
+EXEMPT: dict[tuple[str, str], str] = {
+    (".bottombar .badge", "margin-left"): "nudge off the centre line, not spacing",
+    (".chart-dot", "margin"): "negative half of its own width",
+    (".sr-only", "margin"): "the visually-hidden clip trick",
+    (".donut-total", "font-size"): "SVG user units in a viewBox, not a font size",
+    (".donut-legend .legend-members ul", "padding"): "indent derived from swatch + gap",
+}
+
+
+def _declarations() -> list[tuple[str, str, str]]:
+    """Every (selector, property, value) in the stylesheet, tokens themselves aside."""
+    css = re.sub(r"/\*.*?\*/", "", STYLESHEET.read_text(), flags=re.S)
+    found: list[tuple[str, str, str]] = []
+    stack: list[str] = []
+    for chunk in re.split(r"([{}])", css):
+        if chunk == "{":
+            continue
+        if chunk == "}":
+            if stack:
+                stack.pop()
+            continue
+        head, _, decls = chunk.rpartition(";")
+        body = f"{head};{decls}" if head else decls
+        for decl in body.split(";"):
+            prop, sep, value = decl.partition(":")
+            if not sep:
+                continue
+            prop, value = prop.strip(), value.strip()
+            if prop and value and not prop.startswith("--"):
+                found.append((stack[-1] if stack else "", prop, value))
+        selector = decls.strip().splitlines()[-1].strip() if decls.strip() else ""
+        stack.append(selector)
+    return found
+
+
+_FUNCTION = re.compile(r"[a-z-]*\((?:[^()]|\([^()]*\))*\)")
+
+
+def _is_tokenised(value: str) -> bool:
+    """True when nothing outside a function call is a bare literal."""
+    return all(
+        part in KEYWORDS or part in FREE_VALUES
+        for part in _FUNCTION.sub(" ", value).split()
+    )
+
+
+def test_guarded_properties_use_tokens() -> None:
+    """No guarded property carries a literal outside :root."""
+    offenders = [
+        f"{selector} {{ {prop}: {value} }}"
+        for selector, prop, value in _declarations()
+        if GUARDED.match(prop)
+        and not _is_tokenised(value)
+        and (selector, prop) not in EXEMPT
+    ]
+    assert not offenders, "literal values outside :root:\n" + "\n".join(offenders)
+
+
+def test_exemptions_still_apply() -> None:
+    """An exemption matching nothing is stale."""
+    live = {(selector, prop) for selector, prop, _ in _declarations()}
+    assert not [key for key in EXEMPT if key not in live]


### PR DESCRIPTION
Closes #356. First step of #355, and #357 / #358 / #353 build on the vocabulary this adds.

## What changed

The stylesheet had colour tokens and nothing else, so every size, space, radius, shadow and theme tint was written literally at its use site — 79 `font-size` declarations over 18 distinct values, `44px` six times, `200px` three times, `--surface-alt` referenced with a hardcoded fallback and never defined, `--income` defined twice and used nowhere.

`:root` now carries eight type steps, a 2px spacing grid named by value, five radii, elevation with a dark variant, a focus ring, the layout constants (`--sidebar-w`, `--content-max`, `--axis-gutter`, `--control-min-h`) and one token per theme-dependent colour. 540 `var()` uses, four documented literals left.

Two defects fall out of tokenising the colours: a form error rendered as a pale pink block on a dark page, and `.status-expiring` used a raw dark goldenrod while a theme-aware `--warn` already existed. With every banner tint tokenised, the dark-mode banner override block disappears entirely.

## Not a redesign, and here are the numbers

Measured by rendering the demo database headless before and after, at desktop and phone width, in both themes:

| | before | after |
| --- | --- | --- |
| Ledger row | 39.2px | 40.0px |
| Upcoming row | 34.6px | 35.4px |
| Overdue item | 133.6px | 134.6px |
| Hero metric | 62.7px | 61.6px |
| Card height | 143.1px | 143.1px |

Maximum drift over the 148 snapped box declarations: 0.8px. Four type steps move 1.6px (`.brand`, `.stat .metric-value`, `.y-label.zero`, `.targets-page > h1`).

Four changes are deliberately visible: filter and form inputs meet the 44px touch floor (the search field was 32px), a two-digit nav badge stops being squeezed below its content width, every interactive element gets a focus ring where only three selectors had one, and two column-header rules go from weight 500 to 600.

One control is deliberately **excluded** from the touch floor: the ledger's inline category select. A hundred of those sit in the list, and raising them to 44px cost a third of the visible rows. That is a density decision, so it belongs to #358.

## One fix from outside the token work

The category column was 13rem while it had to hold a 192px select plus the link icon beside it, so all 50 🔗 icons overflowed their cell by 23px at every width and the card clipped them. It comes from the fixed table layout in #360, which is already merged and closed, and it lives in this same file — so it is fixed here: the column goes to 15rem and the select can shrink with its cell.

## Guard

A pytest parses the stylesheet's declarations and fails on a literal outside `:root`, with an exemption table keyed by selector and property, each entry carrying its reason. A second test fails when an exemption stops matching anything, so the list cannot rot. It catches a reintroduced `padding: 7px` or `font-size: 0.93rem`.

stylelint with `stylelint-declaration-strict-value` was the first choice and the rule worked when run by hand, but the plugin is unresolvable from pre-commit's isolated node environment, and fixing that needs a `package.json` plus a node step in CI for one rule.

## Verification

- `1289 passed`, pre-commit clean.
- Home, Month, Operations, Targets and Settings rendered headless at 1280px and 430px, light and dark, with element geometry probed rather than eyeballed. That is where the table above comes from, and it caught both regressions listed as excluded or fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
