### PR TITLE
Reserve the accent colour for actions

### DIFF
--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -118,9 +118,41 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* A name that happens to be navigable is content, not a URL: it keeps the text
+   colour and says what it is on hover and on keyboard focus. --accent is for
+   actions. */
 a {
-  color: var(--accent);
+  color: inherit;
   text-decoration: none;
+}
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+/* Buttons, chips, tiles and nav items: the shape already says it is clickable,
+   so the underline above would only add noise. */
+.btn:hover,
+.btn:focus-visible,
+.tile-action:hover,
+.tile-action:focus-visible,
+.nav-item:hover,
+.nav-item:focus-visible,
+.seg a:hover,
+.seg a:focus-visible,
+.period-switch a:hover,
+.period-switch a:focus-visible,
+.bookmarklet:hover,
+.bookmarklet:focus-visible,
+.link-action:hover,
+.link-action:focus-visible {
+  text-decoration: none;
+}
+
+/* An action written as words, wherever there is no room for a button. */
+.action-link {
+  color: var(--accent);
+  font-weight: 600;
 }
 
 :focus-visible {
@@ -196,6 +228,7 @@ a {
 }
 .banner a {
   margin-left: var(--sp-8);
+  color: var(--accent);
   font-weight: 600;
 }
 .banner-expiring {
@@ -237,6 +270,7 @@ a {
 .card-link {
   display: inline-block;
   margin-top: var(--sp-8);
+  color: var(--accent);
   font-weight: 600;
 }
 
@@ -297,9 +331,6 @@ a {
 }
 .summary .metric-value {
   font-size: var(--fs-xl);
-}
-.tile-action {
-  color: inherit;
 }
 .tile-action:hover,
 .tile-action:focus-visible {
@@ -429,18 +460,6 @@ a {
   flex: 1;
   padding: 0 var(--sp-8);
 }
-/* A name that happens to be navigable reads as content, not as a URL. */
-.up-desc a,
-.attributed-list .op-desc a {
-  color: inherit;
-  text-decoration: none;
-}
-.up-desc a:hover,
-.up-desc a:focus-visible,
-.attributed-list .op-desc a:hover,
-.attributed-list .op-desc a:focus-visible {
-  text-decoration: underline;
-}
 .positive {
   color: var(--good);
 }
@@ -464,6 +483,7 @@ a {
   margin: 0;
 }
 .month-nav a {
+  color: var(--accent);
   font-size: var(--fs-lg);
   padding: 0 var(--sp-12);
 }
@@ -601,13 +621,15 @@ table {
 .load-more-cell {
   text-align: center;
 }
+/* The name of the linked target: a label, quiet enough to sit on 100 ledger
+   rows without turning the column blue. The chip is what makes it navigable. */
 .link-tag {
   display: inline-block;
   vertical-align: middle;
   max-width: 14rem;
   font-size: var(--fs-2xs);
-  color: var(--accent);
-  border: 1px solid var(--accent);
+  color: var(--muted);
+  border: 1px solid var(--border);
   border-radius: var(--radius-xs);
   padding: var(--sp-2) var(--sp-6);
   margin-left: var(--sp-8);
@@ -615,8 +637,7 @@ table {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* Only the anchor form navigates; the same look is used as a plain badge
-   elsewhere, so the affordance has to be on a.link-tag alone. */
+/* Only the anchor form navigates, so the affordance belongs on it alone. */
 a.link-tag {
   text-decoration: none;
   cursor: pointer;
@@ -624,6 +645,7 @@ a.link-tag {
 a.link-tag:hover,
 a.link-tag:focus-visible {
   background: var(--accent);
+  border-color: var(--accent);
   color: var(--on-accent);
   text-decoration: underline;
 }
@@ -1272,16 +1294,23 @@ a.link-tag:focus-visible {
 }
 
 /* --- Month: category drill-down --- */
+/* A category name, drillable: same affordance as a navigable name, because a
+   whole column of them in accent reads as a page of URLs. */
 .cat-toggle {
   background: none;
   border: none;
   padding: 0;
-  color: var(--accent);
+  color: inherit;
   font: inherit;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   cursor: pointer;
   text-align: left;
+}
+.cat-toggle:hover,
+.cat-toggle:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 .cat-toggle[aria-expanded='true']::after {
   content: ' ▾';
@@ -1666,6 +1695,11 @@ a.link-tag:focus-visible {
 .back {
   margin: 0 0 var(--sp-8);
   font-size: var(--fs-sm);
+}
+/* Going back is an action, not a label. */
+.back a,
+.back-link a {
+  color: var(--accent);
 }
 .op-summary {
   display: flex;

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -1775,10 +1775,12 @@ a.link-tag:focus-visible {
 .cand-amount {
   white-space: nowrap;
 }
+/* Why this candidate matched: a label inside the button that is the action, so
+   it stays quiet — the same call as the linked-target chip. */
 .cand-reason {
   font-size: var(--fs-2xs);
-  color: var(--accent);
-  border: 1px solid var(--accent);
+  color: var(--muted);
+  border: 1px solid var(--border);
   border-radius: var(--radius-xs);
   padding: 0 var(--sp-4);
 }

--- a/budget_forecaster/web/templates/fragments/margin_hero.html
+++ b/budget_forecaster/web/templates/fragments/margin_hero.html
@@ -23,7 +23,7 @@
     <div class="metric-value metric-none">—</div>
     <div class="metric-sub">
       {{ _("No forecast yet") }} ·
-      <a href="/targets">{{ _("Add a budget or a planned operation") }}</a>
+      <a class="action-link" href="/targets">{{ _("Add a budget or a planned operation") }}</a>
     </div>
   {% endif %}
 </section>

--- a/budget_forecaster/web/templates/settings.html
+++ b/budget_forecaster/web/templates/settings.html
@@ -141,7 +141,7 @@
   {% else %}
   <p class="hint">{{ _("Run the Swile Enroll bookmarklet on team.swile.co; it copies the token to paste here.") }}</p>
   {% endif %}
-  <p><a href="https://team.swile.co" target="_blank" rel="noopener noreferrer">{{ _("Open team.swile.co") }} ↗</a></p>
+  <p><a class="action-link" href="https://team.swile.co" target="_blank" rel="noopener noreferrer">{{ _("Open team.swile.co") }} ↗</a></p>
   <form method="post" action="/settings/swile/enroll" class="swile-enroll-form">
     <label class="field">
       <span>{{ _("Refresh token") }}</span>

--- a/budget_forecaster/web/templates/target_edit.html
+++ b/budget_forecaster/web/templates/target_edit.html
@@ -32,7 +32,7 @@
                 name='« ' ~ dup.description ~ ' »',
                 amount=dup.amount | signed_eur(currency),
                 period=dup.period_label) }}
-        <a href="/operations/{{ seed.operation_id }}/link?return_to={{ return_to | urlencode }}">{{
+        <a class="action-link" href="/operations/{{ seed.operation_id }}/link?return_to={{ return_to | urlencode }}">{{
           _("Link to {name}").format(name='« ' ~ dup.description ~ ' »') }}</a>
       {% endif %}
     </p>


### PR DESCRIPTION
## What

One rule for the accent colour: it marks an action. A label that happens to navigate keeps the text colour and shows what it is on `:hover` / `:focus-visible`.

The base rule is flipped rather than exception-ridden, so the two inherited-colour rules #346 added become the default and disappear.

| Surface | Before | After |
|---|---|---|
| Ledger description, budget/planned row description, linked target on an operation, Mois drill-down sources | accent | inherited, underlined on hover and focus |
| Mois category names | accent bold | inherited bold, underlined on hover and focus |
| Linked-target chip (`→ Groceries`) | accent text and border | muted; the accent fill on hover is the affordance |
| Buttons, tabs, segmented control, nav items, tiles, bookmarklet | own colours | unchanged, and no underline added on top |
| Back ‹, month arrows, banner actions, "Voir le mois ›" | accent by inheritance | accent, declared |
| "Open team.swile.co", "Add a budget…", "Link to «X»" | accent by inheritance | `.action-link` |

The chip went muted because it is the target's *name*: at accent it turned a 100-row ledger into a blue column, which is the complaint the issue opens on.

## Checks

- Light and dark, rendered from the demo database: ledger, Accueil, Mois, Budgets, operation detail.
- `pytest tests/` — 1302 passed.

Closes #353. Part of #355.

Out of scope, and the second half of the epic's #353 line: the two tooltip systems (the `data-tip` bubble versus native `title`, which never shows on touch).
