### PR TITLE
Soften the surfaces, shadows and motion

### DIFF
--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -7,11 +7,15 @@
      switching costs one declaration and never a second palette. --- */
   color-scheme: light dark;
   --bg: light-dark(#f5f6f8, #14161a);
-  --surface: light-dark(#ffffff, #1e2127);
+  /* Dark: a shadow on a dark background is invisible, so what raises a card is
+     the surface being lighter than the page. */
+  --surface: light-dark(#ffffff, #23272f);
   /* A recessed area inside a card: bar tracks, pills, inset panels. */
   --surface-alt: light-dark(#f5f6f8, #14161a);
   --surface-hover: light-dark(#f5f6f8, #14161a);
-  --text: light-dark(#1c1f26, #e6e8ec);
+  /* Not pure black on white: a softer ink is what stops a dense table from
+     vibrating. */
+  --text: light-dark(#22262e, #e6e8ec);
   /* Text on a --text background: tooltips invert. */
   --text-inverse: light-dark(#f5f6f8, #14161a);
   /* Text on an --accent background. White on the dark theme's lighter accent
@@ -19,6 +23,9 @@
   --on-accent: light-dark(#ffffff, #0d1424);
   --muted: light-dark(#6b7280, #9aa1ac);
   --border: light-dark(#e3e6ea, #2c313a);
+  /* The edge of a raised surface: the shadow separates it, so the line only
+     has to keep the corner crisp. */
+  --border-subtle: light-dark(#edeff2, #2b3038);
   --accent: light-dark(#2f6df6, #5b8dff);
   --good: light-dark(#1f9d55, #3fce7c);
   --bad: light-dark(#d64545, #f0736f);
@@ -57,18 +64,34 @@
   --sp-32: 32px;
 
   /* --- Radii --- */
-  --radius-2xs: 2px;
-  --radius-xs: 4px;
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --radius-2xs: 3px;
+  --radius-xs: 6px;
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
   --radius-pill: 999px;
 
-  /* --- Elevation and focus --- */
-  --shadow: 0 1px 3px light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.4));
+  /* --- Elevation and focus: two layers, a contact shadow and a wide diluted
+     one. A single layer is what makes a card look printed on the page. --- */
+  --shadow: 0 1px 2px light-dark(rgba(15, 23, 42, 0.05), rgba(0, 0, 0, 0.3)),
+    0 8px 24px -6px light-dark(rgba(15, 23, 42, 0.1), rgba(0, 0, 0, 0.45));
+  /* Hover: the same shape, lifted. */
+  --shadow-lift: 0 2px 4px light-dark(rgba(15, 23, 42, 0.06), rgba(0, 0, 0, 0.35)),
+    0 14px 32px -8px light-dark(rgba(15, 23, 42, 0.14), rgba(0, 0, 0, 0.55));
+  /* Small parts — a tooltip, the pill of a segmented control — sit close to
+     the surface: the wide layer would read as a halo on them. */
+  --shadow-sm: 0 1px 2px light-dark(rgba(15, 23, 42, 0.08), rgba(0, 0, 0, 0.4));
   /* 0.12 alpha is invisible on a dark --surface; the bar needs a real one. */
   --shadow-up: 0 -2px 6px light-dark(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.5));
   --focus-ring: 2px solid var(--accent);
+
+  /* --- Motion. Every duration goes through these, which is what lets
+     prefers-reduced-motion switch the whole app off in one place. --- */
+  --dur-fast: 120ms;
+  --dur: 180ms;
+  --ease: cubic-bezier(0.2, 0, 0.2, 1);
+  /* How far a control gives under the finger. */
+  --press: translateY(1px);
 
   /* --- Layout --- */
   --nav-h: 56px;
@@ -81,6 +104,16 @@
   --control-min-h: 44px;
   /* Donut legend swatch; the sub-list indent aligns under it. */
   --swatch-w: 0.8rem;
+}
+
+/* Asking for less motion turns off every transition and the press, because
+   both go through tokens. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-fast: 0ms;
+    --dur: 0ms;
+    --press: none;
+  }
 }
 
 * {
@@ -173,6 +206,11 @@ a:focus-visible {
   color: var(--muted);
   text-align: center;
 }
+/* Both bars, one rule: the bottom one and the sidebar set the colours, this
+   only says how they change. */
+.nav-item {
+  transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+}
 .nav-icon {
   font-size: var(--fs-md);
   line-height: 1;
@@ -230,7 +268,7 @@ a:focus-visible {
 /* --- Cards --- */
 .card {
   background: var(--surface);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   padding: var(--sp-16);
   margin-bottom: var(--sp-16);
@@ -300,8 +338,9 @@ a:focus-visible {
 .tile {
   display: block;
   background: var(--surface);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
   padding: var(--sp-16);
 }
 .summary .tile:first-child {
@@ -310,9 +349,16 @@ a:focus-visible {
 .summary .metric-value {
   font-size: var(--fs-xl);
 }
+.tile-action {
+  transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
 .tile-action:hover,
 .tile-action:focus-visible {
   border-color: var(--accent);
+  box-shadow: var(--shadow-lift);
+}
+.tile-action:active {
+  transform: var(--press);
 }
 /* A settled slot still holds its place, quietly. */
 .metric-none {
@@ -404,6 +450,13 @@ a:focus-visible {
   color: var(--accent);
   font-weight: 600;
   cursor: pointer;
+  transition: border-color var(--dur) var(--ease), transform var(--dur-fast) var(--ease);
+}
+.more-btn:hover {
+  border-color: var(--accent);
+}
+.more-btn:active {
+  transform: var(--press);
 }
 
 /* --- Lists --- */
@@ -510,7 +563,7 @@ table {
   line-height: 1.3;
   padding: var(--sp-6) var(--sp-10);
   border-radius: var(--radius-sm);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
   pointer-events: none;
 }
 .section-row td {
@@ -619,6 +672,7 @@ table {
 a.link-tag {
   text-decoration: none;
   cursor: pointer;
+  transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease), color var(--dur) var(--ease);
 }
 a.link-tag:hover,
 a.link-tag:focus-visible {
@@ -775,7 +829,7 @@ a.link-tag:focus-visible {
 }
 .slice {
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: opacity var(--dur) var(--ease);
 }
 .slices.faded .slice {
   opacity: 0.3;
@@ -931,7 +985,7 @@ a.link-tag:focus-visible {
 }
 .login-card {
   background: var(--surface);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   padding: var(--sp-24);
   width: 100%;
@@ -1214,6 +1268,22 @@ a.link-tag:focus-visible {
   font-size: var(--fs-sm);
   text-align: center;
   cursor: pointer;
+  transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease),
+    transform var(--dur-fast) var(--ease);
+}
+/* A filled button answers with its fill, an outlined one with its edge — and a
+   destructive one keeps its red, hover included. */
+.btn:hover:not(.primary, .danger) {
+  border-color: var(--accent);
+}
+.btn.primary:hover {
+  background: color-mix(in srgb, var(--accent) 88%, var(--text));
+}
+.btn.danger:hover {
+  background: color-mix(in srgb, var(--bad) 10%, transparent);
+}
+.btn:active {
+  transform: var(--press);
 }
 .btn.primary {
   background: var(--accent);
@@ -1352,6 +1422,7 @@ a.link-tag:focus-visible {
    not an anchor — that carries the click. */
 .attributed-row {
   cursor: pointer;
+  transition: background var(--dur-fast) var(--ease);
 }
 .attributed-row:hover {
   background: var(--surface-hover);
@@ -1406,6 +1477,13 @@ a.link-tag:focus-visible {
   .ledger .desc {
     overflow-wrap: anywhere;
   }
+}
+/* The ledger answers the pointer like the other lists do. */
+.op-row {
+  transition: background var(--dur-fast) var(--ease);
+}
+.op-row:hover {
+  background: var(--surface-hover);
 }
 .cat-actions {
   display: flex;
@@ -1643,11 +1721,21 @@ a.link-tag:focus-visible {
   font-family: inherit;
   cursor: pointer;
 }
+.seg a,
+.seg button {
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
+/* The idle side of the control answers the pointer too, or only the option you
+   already picked reacts. */
+.seg a:hover:not(.active),
+.seg button:hover:not(.active) {
+  color: var(--text);
+}
 .seg a.active,
 .seg button.active {
   background: var(--surface);
   color: var(--accent);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
 }
 .list-head {
   display: flex;
@@ -1661,6 +1749,7 @@ a.link-tag:focus-visible {
 }
 .target-row {
   cursor: pointer;
+  transition: background var(--dur-fast) var(--ease);
 }
 .target-row:hover {
   background: var(--surface-hover);
@@ -1745,9 +1834,13 @@ a.link-tag:focus-visible {
   font-variant-numeric: tabular-nums;
   cursor: pointer;
   text-align: left;
+  transition: border-color var(--dur) var(--ease), transform var(--dur-fast) var(--ease);
 }
 .candidate:hover {
   border-color: var(--accent);
+}
+.candidate:active {
+  transform: var(--press);
 }
 /* An author display rule beats the UA [hidden] rule, so say it explicitly. */
 .candidate[hidden] {
@@ -1972,6 +2065,7 @@ a.link-tag:focus-visible {
   padding: var(--sp-8) var(--sp-10);
   border-radius: var(--radius-sm);
   cursor: pointer;
+  transition: background var(--dur-fast) var(--ease);
 }
 .bank-option:hover {
   background: color-mix(in srgb, var(--good) 10%, transparent);
@@ -1983,18 +2077,6 @@ a.link-tag:focus-visible {
   display: inline;
   margin-left: var(--sp-8);
 }
-.link-button {
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  color: inherit;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 /* --- Backups --- */
 .backups {
   width: 100%;

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -60,6 +60,7 @@
   --sp-12: 12px;
   --sp-14: 14px;
   --sp-16: 16px;
+  --sp-20: 20px;
   --sp-24: 24px;
   --sp-32: 32px;
 
@@ -93,7 +94,11 @@
   /* How far a control gives under the finger. */
   --press: translateY(1px);
 
-  /* --- Layout --- */
+  /* --- Layout ---
+     Air, in two steps: a phone spends its width on content, a wide screen has
+     room to spare. Both are raised in the wide block below. */
+  --card-pad: var(--sp-20);
+  --stack-gap: var(--sp-16);
   --nav-h: 56px;
   --sidebar-w: 200px;
   --content-max: 900px;
@@ -125,7 +130,7 @@ body {
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   background: var(--bg);
   color: var(--text);
-  line-height: 1.4;
+  line-height: 1.5;
   font-variant-numeric: tabular-nums;
 }
 
@@ -270,8 +275,8 @@ a:focus-visible {
   background: var(--surface);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--sp-16);
-  margin-bottom: var(--sp-16);
+  padding: var(--card-pad);
+  margin-bottom: var(--stack-gap);
   box-shadow: var(--shadow);
 }
 .card-head {
@@ -281,7 +286,7 @@ a:focus-visible {
 }
 .card-head h2 {
   font-size: var(--fs-base);
-  margin: 0 0 var(--sp-8);
+  margin: 0 0 var(--sp-12);
 }
 .card-link {
   display: inline-block;
@@ -326,8 +331,8 @@ a:focus-visible {
 .summary {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: var(--sp-16);
-  margin-bottom: var(--sp-16);
+  gap: var(--stack-gap);
+  margin-bottom: var(--stack-gap);
 }
 /* Below this the two secondary tiles cannot hold an amount side by side. */
 @media (max-width: 26rem) {
@@ -341,7 +346,7 @@ a:focus-visible {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
-  padding: var(--sp-16);
+  padding: var(--card-pad);
 }
 .summary .tile:first-child {
   grid-column: 1 / -1;
@@ -417,7 +422,7 @@ a:focus-visible {
 .subhead {
   font-size: var(--fs-sm);
   color: var(--muted);
-  margin: var(--sp-14) 0 var(--sp-4);
+  margin: var(--sp-20) 0 var(--sp-6);
 }
 
 /* Readable Actual/Planned columns on the home month summary. */
@@ -532,7 +537,7 @@ table {
 .review td,
 .ledger th,
 .ledger td {
-  padding: var(--sp-6) var(--sp-8);
+  padding: var(--sp-8) var(--sp-10);
   border-bottom: 1px solid var(--border);
   text-align: left;
 }
@@ -1021,6 +1026,11 @@ a.link-tag:focus-visible {
 
 /* --- Desktop: sidebar replaces the bottom bar --- */
 @media (min-width: 1024px) {
+  /* The width a phone spends on content is spare room here. */
+  :root {
+    --card-pad: var(--sp-24);
+    --stack-gap: var(--sp-24);
+  }
   .bottombar {
     display: none;
   }
@@ -1063,7 +1073,7 @@ a.link-tag:focus-visible {
   .home-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: var(--sp-16);
+    gap: var(--stack-gap);
   }
   /* One card left (no budget or planned operation this month yet) takes the
      whole row rather than leaving half of it empty. */

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -171,17 +171,25 @@ a:focus-visible {
   font-weight: 600;
 }
 
-/* A row that answers the pointer. The highlight is the affordance, so the names
-   inside stop underlining — one signal per row, and it covers the whole line
-   instead of the few words that happen to be a link. The chip keeps its own,
-   because it goes somewhere else. Focus-within lights the row for the keyboard
-   too. */
+/* A row that answers the pointer, and where `data-href` says so, a row that is
+   the click target. The highlight is the affordance, so the names inside stop
+   underlining — one signal per row, covering the whole line instead of the few
+   words that happen to be a link. The chip keeps its own, because it goes
+   somewhere else.
+
+   :has(:focus-visible) and not :focus-within: clicking a link or a <summary>
+   leaves the focus inside the row, and the row would stay lit after the pointer
+   has gone. Keyboard focus still lights it. */
 .row-hover {
   transition: background var(--dur-fast) var(--ease);
 }
 .row-hover:hover,
-.row-hover:focus-within {
+.row-hover:has(:focus-visible) {
   background: var(--surface-hover);
+}
+.row-hover[data-href],
+.review tr.row-hover {
+  cursor: pointer;
 }
 .row-hover a:not(.link-tag):hover,
 .row-hover a:not(.link-tag):focus-visible,
@@ -1449,9 +1457,6 @@ a.link-tag:focus-visible {
 }
 /* The row holds two links with different destinations, so it is the row —
    not an anchor — that carries the click. */
-.attributed-row {
-  cursor: pointer;
-}
 .src-meta,
 .op-amount {
   color: var(--muted);
@@ -1764,9 +1769,6 @@ a.link-tag:focus-visible {
 .list-head h2 {
   font-size: var(--fs-base);
   margin: 0;
-}
-.target-row {
-  cursor: pointer;
 }
 .target-row.inactive {
   opacity: 0.55;

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -171,6 +171,25 @@ a:focus-visible {
   font-weight: 600;
 }
 
+/* A row that answers the pointer. The highlight is the affordance, so the names
+   inside stop underlining — one signal per row, and it covers the whole line
+   instead of the few words that happen to be a link. The chip keeps its own,
+   because it goes somewhere else. Focus-within lights the row for the keyboard
+   too. */
+.row-hover {
+  transition: background var(--dur-fast) var(--ease);
+}
+.row-hover:hover,
+.row-hover:focus-within {
+  background: var(--surface-hover);
+}
+.row-hover a:not(.link-tag):hover,
+.row-hover a:not(.link-tag):focus-visible,
+.row-hover .cat-toggle:hover,
+.row-hover .cat-toggle:focus-visible {
+  text-decoration: none;
+}
+
 :focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--sp-2);
@@ -1432,10 +1451,6 @@ a.link-tag:focus-visible {
    not an anchor — that carries the click. */
 .attributed-row {
   cursor: pointer;
-  transition: background var(--dur-fast) var(--ease);
-}
-.attributed-row:hover {
-  background: var(--surface-hover);
 }
 .src-meta,
 .op-amount {
@@ -1487,13 +1502,6 @@ a.link-tag:focus-visible {
   .ledger .desc {
     overflow-wrap: anywhere;
   }
-}
-/* The ledger answers the pointer like the other lists do. */
-.op-row {
-  transition: background var(--dur-fast) var(--ease);
-}
-.op-row:hover {
-  background: var(--surface-hover);
 }
 .cat-actions {
   display: flex;
@@ -1759,10 +1767,6 @@ a.link-tag:focus-visible {
 }
 .target-row {
   cursor: pointer;
-  transition: background var(--dur-fast) var(--ease);
-}
-.target-row:hover {
-  background: var(--surface-hover);
 }
 .target-row.inactive {
   opacity: 0.55;

--- a/budget_forecaster/web/static/month.js
+++ b/budget_forecaster/web/static/month.js
@@ -28,18 +28,6 @@
   );
 })();
 
-// Clicking an attributed operation row opens it. Delegated, because the rows
-// arrive with the drill-down fragment; the inner links keep their own targets.
-(function () {
-  'use strict';
-
-  document.addEventListener('click', function (event) {
-    var row = event.target.closest('.attributed-row[data-href]');
-    if (!row || event.target.closest('a')) return;
-    window.location.href = row.dataset.href;
-  });
-})();
-
 // Expand/collapse a category drill-down under its month row. The open category
 // is mirrored into the URL (?open=<cat>) so the back button and the "return to"
 // links from edit/detail pages land back on the same expanded row.
@@ -69,16 +57,29 @@
     window.history.replaceState(null, '', url);
   }
 
+  function toggle(btn) {
+    if (btn.getAttribute('aria-expanded') === 'true') {
+      collapse(btn);
+      syncUrl(null);
+    } else {
+      expand(btn, true);
+      syncUrl(btn.dataset.cat);
+    }
+  }
+
   document.querySelectorAll('.cat-toggle').forEach(function (btn) {
     btn.addEventListener('click', function () {
-      if (btn.getAttribute('aria-expanded') === 'true') {
-        collapse(btn);
-        syncUrl(null);
-      } else {
-        expand(btn, true);
-        syncUrl(btn.dataset.cat);
-      }
+      toggle(btn);
     });
+  });
+
+  // The row highlights as one, so the figures open the drill-down too — the
+  // category name is where the keyboard and a no-JS reader reach it.
+  document.addEventListener('click', function (event) {
+    if (event.target.closest('a, button, select, input, label, summary')) return;
+    var row = event.target.closest('.review tr.row-hover');
+    var btn = row && row.querySelector('.cat-toggle');
+    if (btn) toggle(btn);
   });
 
   // Re-open the category carried in the URL (a previous expand, or a "return to"

--- a/budget_forecaster/web/static/rows.js
+++ b/budget_forecaster/web/static/rows.js
@@ -1,0 +1,25 @@
+// A highlighted row is a click target: anywhere on it goes where its `data-href`
+// says. The inner link stays for the keyboard and for no-JS.
+//
+// Delegated, because rows arrive from htmx swaps: the ledger replaces a row on
+// every categorization, and the month drill-down is a fragment.
+(function () {
+  'use strict';
+
+  // Anything with an action of its own wins: a chip going elsewhere, the
+  // category select, a selection checkbox, the link icon.
+  var OWN_ACTION = 'a, button, select, input, label, summary, textarea';
+
+  document.addEventListener('click', function (event) {
+    var row = event.target.closest('.row-hover[data-href]');
+    if (!row || event.target.closest(OWN_ACTION)) return;
+    window.location.href = row.dataset.href;
+  });
+
+  // Rows that opt into a tab stop (role="link" + tabindex) answer Enter too.
+  document.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter') return;
+    var row = event.target.closest('.row-hover[data-href][role="link"]');
+    if (row) window.location.href = row.dataset.href;
+  });
+})();

--- a/budget_forecaster/web/static/targets.js
+++ b/budget_forecaster/web/static/targets.js
@@ -33,15 +33,4 @@
     syncSplit();
     splitSection.addEventListener('toggle', syncSplit);
   }
-
-  // Whole management row is clickable (the inner link keeps keyboard/no-JS access).
-  document.querySelectorAll('.target-row[data-href]').forEach(function (row) {
-    row.addEventListener('click', function (event) {
-      if (event.target.closest('a')) return;
-      window.location.href = row.dataset.href;
-    });
-    row.addEventListener('keydown', function (event) {
-      if (event.key === 'Enter') window.location.href = row.dataset.href;
-    });
-  });
 })();

--- a/budget_forecaster/web/templates/base.html
+++ b/budget_forecaster/web/templates/base.html
@@ -73,6 +73,7 @@
     <nav class="bottombar" aria-label="{{ _('Sections') }}">
       {{ navlinks("bottom") }}
     </nav>
+    <script src="/static/rows.js" defer></script>
     <script src="/static/tooltips.js" defer></script>
     <script src="/static/confirm.js" defer></script>
   </body>

--- a/budget_forecaster/web/templates/fragments/category_detail.html
+++ b/budget_forecaster/web/templates/fragments/category_detail.html
@@ -13,7 +13,7 @@
   {% if detail.sources %}
   <ul class="source-list">
     {% for s in detail.sources %}
-    <li>
+    <li class="row-hover">
       <a href="/targets/{{ s.kind }}/{{ s.source_id }}?return_to={{ rt }}">
         <span class="src-desc">{{ s.description }}</span>
         <span class="src-meta">{{ s.amount | signed_eur(currency) }} · {{ s.periodicity }}</span>
@@ -32,7 +32,7 @@
        whole line stays clickable through data-href, the description carries the
        real anchor for the keyboard and for no-JS. #}
     {% for op in detail.operations %}
-    <li class="attributed-row" data-href="/operations/{{ op.operation_id }}?return_to={{ rt }}">
+    <li class="attributed-row row-hover" data-href="/operations/{{ op.operation_id }}?return_to={{ rt }}">
       <span class="op-date">{{ op.operation_date | frdate }}</span>
       <span class="op-desc">
         <a href="/operations/{{ op.operation_id }}?return_to={{ rt }}">{{ op.description }}</a>

--- a/budget_forecaster/web/templates/fragments/ledger_row.html
+++ b/budget_forecaster/web/templates/fragments/ledger_row.html
@@ -2,7 +2,8 @@
 {# The active filters ride along, so every link comes back to the same ledger. #}
 {% set ledger_url = '/operations?' ~ query if query else '/operations' %}
 {% set back = ledger_url | urlencode %}
-<tr id="op-row-{{ row.operation.unique_id }}" class="op-row row-hover">
+<tr id="op-row-{{ row.operation.unique_id }}" class="op-row row-hover"
+    data-href="/operations/{{ row.operation.unique_id }}?return_to={{ back }}">
   <td class="select-cell">
     <input type="checkbox" name="ids" value="{{ row.operation.unique_id }}"
            class="row-select" aria-label="{{ _('Select operation') }}" />

--- a/budget_forecaster/web/templates/fragments/ledger_row.html
+++ b/budget_forecaster/web/templates/fragments/ledger_row.html
@@ -2,7 +2,7 @@
 {# The active filters ride along, so every link comes back to the same ledger. #}
 {% set ledger_url = '/operations?' ~ query if query else '/operations' %}
 {% set back = ledger_url | urlencode %}
-<tr id="op-row-{{ row.operation.unique_id }}" class="op-row">
+<tr id="op-row-{{ row.operation.unique_id }}" class="op-row row-hover">
   <td class="select-cell">
     <input type="checkbox" name="ids" value="{{ row.operation.unique_id }}"
            class="row-select" aria-label="{{ _('Select operation') }}" />

--- a/budget_forecaster/web/templates/fragments/overdue_row.html
+++ b/budget_forecaster/web/templates/fragments/overdue_row.html
@@ -3,7 +3,7 @@
    the card. Open when the user was already acting on it, closed on arrival. #}
 <li class="overdue-item" id="overdue-{{ row.planned_operation_id }}-{{ row.iteration_date }}">
   <details class="overdue-disclosure"{{ ' open' | safe if row_open }}>
-    <summary class="overdue-summary">
+    <summary class="overdue-summary row-hover">
       <span class="overdue-head">
         <span class="overdue-desc">{{ row.description }}</span>
         <span class="overdue-amount {{ 'positive' if row.amount > 0 else 'negative' }}">

--- a/budget_forecaster/web/templates/fragments/upcoming_items.html
+++ b/budget_forecaster/web/templates/fragments/upcoming_items.html
@@ -1,5 +1,5 @@
 {% for item in upcoming %}
-  <li>
+  <li class="row-hover">
     <span class="up-date">{{ item.iteration_date | frdate }}</span>
     <span class="up-desc">
       {%- if item.planned_operation_id %}

--- a/budget_forecaster/web/templates/fragments/upcoming_items.html
+++ b/budget_forecaster/web/templates/fragments/upcoming_items.html
@@ -1,5 +1,7 @@
 {% for item in upcoming %}
-  <li class="row-hover">
+  {%- set target = ('/targets/planned/' ~ item.planned_operation_id ~ '?return_to=/')
+                   if item.planned_operation_id else none %}
+  <li {% if target %}class="row-hover" data-href="{{ target }}"{% endif %}>
     <span class="up-date">{{ item.iteration_date | frdate }}</span>
     <span class="up-desc">
       {%- if item.planned_operation_id %}

--- a/budget_forecaster/web/templates/month.html
+++ b/budget_forecaster/web/templates/month.html
@@ -16,7 +16,7 @@
 
 {% macro cat_row(row) %}
   {% set month_str = view.month.strftime('%Y-%m') %}
-  <tr class="{{ 'income' if row.is_income else 'expense' }}">
+  <tr class="row-hover {{ 'income' if row.is_income else 'expense' }}">
     <td class="cat">
       <button type="button" class="cat-toggle" aria-expanded="false"
               data-target="detail-{{ row.key }}"

--- a/budget_forecaster/web/templates/targets.html
+++ b/budget_forecaster/web/templates/targets.html
@@ -46,7 +46,7 @@
       <tbody>
         {% for row in rows %}
         {% set target_url = "/targets/" ~ row.kind ~ "/" ~ row.id ~ "?return_to=" ~ (base | urlencode) %}
-        <tr class="target-row {{ '' if row.active else 'inactive' }}" tabindex="0" role="link"
+        <tr class="target-row row-hover {{ '' if row.active else 'inactive' }}" tabindex="0" role="link"
             data-href="{{ target_url }}">
           <td data-label="{{ _('Description') }}"><a href="{{ target_url }}">{{ row.description }}</a></td>
           <td class="num {{ 'positive' if row.amount > 0 else 'negative' }}"

--- a/tests/web/.custom.dic
+++ b/tests/web/.custom.dic
@@ -14,6 +14,7 @@ grey
 htmx
 http
 hx
+js
 mis
 oob
 orchestrator

--- a/tests/web/test_pages.py
+++ b/tests/web/test_pages.py
@@ -267,7 +267,7 @@ class TestReachingTheNamedTarget:
             "",
         )
         assert tagged, "a drill-down should show an attributed linked operation"
-        assert 'class="attributed-row" data-href="/operations/' in tagged
+        assert re.search(r'class="attributed-row[^"]*" data-href="/operations/', tagged)
         assert client.get(self._target_href(tagged)).status_code == 200
 
 

--- a/tests/web/test_pages.py
+++ b/tests/web/test_pages.py
@@ -220,9 +220,11 @@ class TestReachingTheNamedTarget:
         assert 'href="/operations?category=RENT"' in page.text
 
     def test_every_link_in_the_row_keeps_the_filters(self, client: TestClient) -> None:
-        """A row's links all lead back where the row was read."""
+        """A row's destinations all lead back where the row was read."""
         row = self._linked_row(client, "category=RENT")
-        assert row.count("return_to=/operations%3Fcategory%3DRENT") == 3
+        returns = re.findall(r"return_to=([^\"&]+)", row)
+        assert returns, "the row should carry return links"
+        assert set(returns) == {"/operations%3Fcategory%3DRENT"}
 
     def test_the_operation_detail_opens_the_target(self, client: TestClient) -> None:
         """The phone layout hides the ledger's link icon, so the detail page carries it."""
@@ -331,3 +333,33 @@ class TestHomeKeepsItsShape:
         assert "Rien à classer" in quiet
         assert "overdue-item" not in quiet
         assert self._slots(quiet) == busy
+
+
+class TestTheRowIsTheClickTarget:
+    """A row that highlights under the pointer takes the click anywhere on it."""
+
+    def test_a_ledger_row_opens_the_operation_it_shows(
+        self, client: TestClient
+    ) -> None:
+        """The row's destination is the one its description already points at."""
+        html = client.get("/operations").text
+        row = html.split('<tr id="op-row-')[1]
+        row = row[: row.find("</tr>")]
+        found = re.search(r'data-href="(/operations/[^"]+)"', row)
+        assert found, "a ledger row should carry its own destination"
+        href = found.group(1).replace("&amp;", "&")
+        assert client.get(href, follow_redirects=True).status_code == 200
+        # The anchor is what a keyboard and a no-JS browser use; same place.
+        assert found.group(1).split("?")[0] in row.split('<a href="')[1]
+
+    def test_an_upcoming_row_never_highlights_without_a_destination(
+        self, client: TestClient
+    ) -> None:
+        """A highlight that leads nowhere promises a click that does nothing."""
+        home = client.get("/").text
+        listing = home.split('class="upcoming-list"')[1]
+        listing = listing[: listing.find("</ul>")]
+        rows = re.findall(r"<li([^>]*)>", listing)
+        assert rows, "the demo home should list upcoming items"
+        for attributes in rows:
+            assert ("row-hover" in attributes) == ("data-href" in attributes)

--- a/tests/web/test_stylesheet_tokens.py
+++ b/tests/web/test_stylesheet_tokens.py
@@ -38,6 +38,7 @@ KEYWORDS = {
 FREE = re.compile(r"^(0|1|[0-9]*\.[0-9]+)$")
 
 _COLOUR = re.compile(r"#[0-9a-fA-F]{3,8}\b|\brgba?\(")
+_TIME = re.compile(r"\d+(\.\d+)?m?s\b")
 
 # selector -> why this one stays literal. Keys are the selector as written, with
 # whitespace collapsed. Anything absent must use a token, so an entry here is a
@@ -121,6 +122,27 @@ def test_guarded_properties_use_tokens() -> None:
         if GUARDED.match(prop) and not _is_tokenised(value) and selector not in EXEMPT
     ]
     assert not offenders, "literal values outside :root:\n" + "\n".join(offenders)
+
+
+def test_motion_goes_through_the_duration_tokens() -> None:
+    """A duration written at a use site is one prefers-reduced-motion cannot
+    switch off."""
+    offenders = [
+        f"{selector} {{ {prop}: {value} }}"
+        for selector, prop, value in _declarations()
+        if prop.startswith(("transition", "animation")) and _TIME.search(value)
+    ]
+    assert not offenders, "durations outside :root:\n" + "\n".join(offenders)
+
+
+def test_reduced_motion_zeroes_every_motion_token() -> None:
+    """Reaching one token and missing another leaves half the app moving."""
+    css = STYLESHEET.read_text()
+    start = css.find("@media (prefers-reduced-motion: reduce)")
+    assert start != -1, "no prefers-reduced-motion block"
+    block = css[start : css.find("\n}\n", css.find("{", start))]
+    for token in ("--dur", "--dur-fast", "--press"):
+        assert f"{token}:" in block, f"{token} keeps its motion under reduce"
 
 
 def test_a_theme_is_one_declaration_per_token() -> None:


### PR DESCRIPTION
> Stacked on #366 (issue #354), itself on #365 (issue #353). Review those first; each base retargets to `main` as the one below merges.

## What

The app had one geometry and one flat shadow, and nothing moved when you pressed it. Four changes, all through tokens.

| Decided | Change |
|---|---|
| Radii | One step up: cards and tiles 12 → 16, controls 8 → 10, chips 4 → 6 |
| Shadows | Two layers — a 1px contact shadow and a wide diluted one — plus `--shadow-lift` for hover and `--shadow-sm` for small parts, where the wide layer reads as a halo. The card border drops to `--border-subtle` since the shadow is what separates it |
| Motion | `--dur` / `--dur-fast` / `--ease` / `--press`, on buttons, tiles, ledger and list rows, chips, the segmented control and the nav. Controls give 1px under the finger |
| Surfaces | Light: a softer ink than near-black. Dark: the card surface is lighter than the page, because a shadow on a dark background shows nothing |

`prefers-reduced-motion: reduce` zeroes the three motion tokens on `:root`, so every transition and the press go quiet from one place.

Two things found in the review of the PRs below, fixed here since they are this PR's subject: the idle side of a segmented control had no hover feedback, and `.link-button` was dead CSS.

## Checks

- Accueil, Opérations, Budgets and Réglages rendered light and dark: cards read as raised in both, the dark primary button label is legible on the accent fill.
- Two new stylesheet guards, both mutation-checked (they fail when the rule is broken): no duration may be written at a use site, and the reduced-motion block must zero every motion token.
- `pytest tests/` — 1309 passed.

Closes #367. Part of #355.
