### PR TITLE
feat: categorize an operation from its detail page

### DIFF
--- a/budget_forecaster/web/routes/operations.py
+++ b/budget_forecaster/web/routes/operations.py
@@ -189,6 +189,7 @@ async def operation_detail(
         active="operations",
         operation=operation,
         current=linking.current_link(app, operation_id),
+        categories=sorted_categories(),
         currency=app.currency,
         return_to=_safe_back(return_to),
     )
@@ -312,20 +313,33 @@ async def categorize_one(
     request: Request,
     app: ApplicationService = Depends(get_app_service),
     filters: LedgerFilters = Depends(get_filters),
+    view: str = "row",
 ) -> Response:
-    """Categorize a single operation inline; swap its row + refresh the badge."""
+    """Categorize a single operation; swap back what the caller shows of it.
+
+    The ledger asks for its row, the detail page for its category field. Both get
+    the badge refreshed out of band.
+    """
     form = await request.form()
     if (category := _category(str(form.get("category", "")))) is None:
         return Response(status_code=400)
     app.categorize_operations((operation_id,), category)
     app.save_operation_changes()
     refresh_forecast(app)
-    row = _rows(app, (app.get_operation_by_id(operation_id),))[0]
+    operation = app.get_operation_by_id(operation_id)
+    if view == "detail":
+        return render_template(
+            request,
+            "fragments/detail_cat_and_badge.html",
+            active="operations",
+            operation=operation,
+            categories=sorted_categories(),
+        )
     return render_template(
         request,
         "fragments/row_and_badge.html",
         active="operations",
-        row=row,
+        row=_rows(app, (operation,))[0],
         categories=sorted_categories(),
         currency=app.currency,
         query=_query(filters),

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -2069,6 +2069,22 @@ a.link-tag:focus-visible {
 .detail-grid dd {
   margin: 0;
 }
+/* The one editable line of the detail grid, so it wears the form-control look
+   rather than the ledger's dense one. Capped: the grid column is the width left
+   over, which a category name never needs. 1rem keeps iOS from zooming the page
+   when the select takes focus. */
+.detail-category {
+  width: 100%;
+  max-width: 16rem;
+  min-height: var(--control-min-h);
+  padding: var(--sp-8);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-base);
+}
 
 /* --- Desktop tweaks --- */
 @media (min-width: 1024px) {

--- a/budget_forecaster/web/static/app.css
+++ b/budget_forecaster/web/static/app.css
@@ -2061,6 +2061,9 @@ a.link-tag:focus-visible {
   grid-template-columns: auto 1fr;
   gap: var(--sp-6) var(--sp-16);
   margin: 0;
+  /* The rows holding a control are taller than their label, which would leave
+     the label hanging at the top edge. */
+  align-items: center;
 }
 .detail-grid dt {
   color: var(--muted);

--- a/budget_forecaster/web/templates/fragments/detail_cat_and_badge.html
+++ b/budget_forecaster/web/templates/fragments/detail_cat_and_badge.html
@@ -1,0 +1,2 @@
+{% include "fragments/detail_category.html" %}
+{% include "fragments/uncat_oob.html" %}

--- a/budget_forecaster/web/templates/fragments/detail_category.html
+++ b/budget_forecaster/web/templates/fragments/detail_category.html
@@ -1,0 +1,14 @@
+{# The category field of the detail page: the same select the ledger row carries,
+   swapping itself so the page around it stays put. #}
+<dd id="op-category">
+  <select class="detail-category" name="category"
+          hx-post="/operations/{{ operation.unique_id }}/categorize?view=detail"
+          hx-target="#op-category"
+          hx-swap="outerHTML"
+          hx-trigger="change"
+          aria-label="{{ _('Category') }}">
+    {% for c in categories %}
+      <option value="{{ c.value }}" {{ 'selected' if operation.category == c }}>{{ c.value | category_name }}</option>
+    {% endfor %}
+  </select>
+</dd>

--- a/budget_forecaster/web/templates/operation_detail.html
+++ b/budget_forecaster/web/templates/operation_detail.html
@@ -13,7 +13,7 @@
     <dt>{{ _("Amount") }}</dt>
     <dd class="{{ 'positive' if operation.amount > 0 else 'negative' }}">{{ operation.amount | signed_eur(currency) }}</dd>
     <dt>{{ _("Category") }}</dt>
-    <dd>{{ operation.category.value | category_name }}</dd>
+    {% include "fragments/detail_category.html" %}
     <dt>{{ _("Link") }}</dt>
     <dd>
       {% if current %}

--- a/docs/user/web-app.md
+++ b/docs/user/web-app.md
@@ -159,6 +159,10 @@ In Opérations, each row carries a category dropdown: change it and the row upda
 the spot. The "N to categorize" badge on the Operations tab counts what is still
 uncategorized and drops as you go.
 
+An operation's own page carries the same dropdown, on the Catégorie line. It is where
+you have the date, the amount and the link in front of you, so the category can be fixed
+there rather than by finding the row again in the ledger.
+
 To categorize several at once, tick the rows you want. A bar appears at the bottom with
 a category picker; choose one and apply it to the whole selection. It starts on
 "Choisissez une catégorie…", and "Catégoriser" stays out of reach until you pick one, so

--- a/tests/web/test_editing.py
+++ b/tests/web/test_editing.py
@@ -1,4 +1,4 @@
-"""Write routes (#305): target CRUD/split, categorize, link, and the drill-down.
+"""Write routes: target CRUD/split, categorize, link, and the drill-down.
 
 Each test drives the HTTP layer over a copy of the demo database and checks the
 observable result (persisted state, refreshed fragment, forecast reload).
@@ -286,6 +286,48 @@ class TestCategorize:
         )
         after = self._uncategorized_ids(client)
         assert len(after) == len(before) - 1
+
+    def test_the_detail_page_offers_the_category_as_a_select(
+        self, client: TestClient
+    ) -> None:
+        """The detail page carries an editable category, starting on the one the
+        operation has."""
+        ids = self._uncategorized_ids(client)
+        assert ids, "demo database should have uncategorized operations"
+        html = client.get(f"/operations/{ids[0]}").text
+        select = re.search(r'<select class="detail-category".*?</select>', html, re.S)
+        assert select, "the detail page should carry a category select"
+        assert '<option value="uncategorized" selected>' in select.group(0)
+
+    def test_detail_categorize_swaps_the_field_and_the_badge(
+        self, client: TestClient
+    ) -> None:
+        """The field comes back alone, with the badge OOB, and the value persists."""
+        ids = self._uncategorized_ids(client)
+        response = client.post(
+            f"/operations/{ids[0]}/categorize?view=detail",
+            data={"category": "groceries"},
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 200
+        assert 'id="op-category"' in response.text
+        assert 'hx-swap-oob="true"' in response.text
+        assert 'id="op-row-' not in response.text
+        reloaded = client.get(f"/operations/{ids[0]}").text
+        assert '<option value="groceries" selected>' in reloaded
+
+    def test_detail_categorize_rejects_an_unknown_category(
+        self, client: TestClient
+    ) -> None:
+        """An unknown value is refused here as it is from the ledger row."""
+        ids = self._uncategorized_ids(client)
+        response = client.post(
+            f"/operations/{ids[0]}/categorize?view=detail",
+            data={"category": "not-a-category"},
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 400
+        assert self._uncategorized_ids(client) == ids
 
     def test_bulk_categorize_applies_to_all_selected(self, client: TestClient) -> None:
         """Bulk categorization re-renders the ledger area and the badge."""


### PR DESCRIPTION
The category line of the operation detail page was read-only, so fixing a category meant going back to the ledger and finding the row again. It now carries the same htmx select the ledger row does.

## What changed

| Piece | Change |
|---|---|
| Detail route | passes the category list to the page |
| `categorize_one` | picks its response from a `view` discriminator: the ledger asks for its row, the detail page for its category field |
| `detail_category.html` | the `<dd>` with the select, included by the page and swapped back by the endpoint |
| `detail_cat_and_badge.html` | that field plus the out-of-band badge refresh, mirroring `row_and_badge.html` |
| CSS | the select wears the form-control look, capped at 16rem, 44px tall and 1rem so a phone can tap it without the page zooming |

One service call and one validation for both paths: `_category()` already answers 400 on an unknown value, so the rejection criterion needed tests rather than code.

## Test plan

`pytest tests/` — 1322 passed. Three new tests in `TestCategorize`: the page offers the select on the operation's current category, a change swaps the field alone plus the badge and persists, and an unknown value is refused with a 400 that changes nothing.

Rendered locally on the demo database at 390px and 1280px: the select takes the column on a phone and stays at 16rem on a desktop.

Also in here: the `test_editing.py` module docstring cited an issue number, which the comment conventions forbid.

Closes #371